### PR TITLE
[remat3] plumb policies at user level at trace time

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -37,7 +37,8 @@ from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
-from jax._src.interpreters.remat import remat_transform
+from jax._src.interpreters.remat import (
+    remat_transform, policy_context, current_policy)
 from jax._src.hijax import HiPrim, call_hi_primitive_p, Static
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import convolution as lax_convolution
@@ -531,10 +532,6 @@ def _saved_residuals(jaxpr: core.Jaxpr,
   def get_name(eqn) -> str | None:
     if eqn.primitive is name_p:
       return eqn.params['name']
-    elif (eqn.primitive is call_hi_primitive_p
-          and isinstance(p := eqn.params['_prim'],
-                         (CheckpointName, CheckpointNameFwd))):
-      return p.name
 
   # TODO(mattjj): actually we want to flag this case as problematic, ie some
   # other consumer of the input to a name_p
@@ -551,6 +548,9 @@ def _saved_residuals(jaxpr: core.Jaxpr,
           results.append((v.aval,
                           f"output of jitted function '{eqn.params['name']}' "
                           f"from {src}"))
+        elif eqn.primitive is call_hi_primitive_p:
+          prim_name = type(eqn.params['_prim']).__name__
+          results.append((v.aval, f'output of {prim_name} from {src}'))
         else:
           results.append((v.aval, f'output of {eqn.primitive.name} from {src}'))
 
@@ -943,7 +943,7 @@ def checkpoint_name(x, name):
 
 def checkpoint_name_fwd(x, name):
   if config.remat3.value:
-    return tree_map(lambda x: CheckpointNameFwd(name, typeof(x))(x), x)
+    return tree_map(lambda x: checkpoint_name3(name, x, fwd=True), x)
   return tree_map(partial(name_p.bind, name=name), x)
 
 name_p.def_impl(lambda x, *, name: x)
@@ -984,8 +984,19 @@ def _remat_state_discharge_rule(
 # TODO
 #  [ ] zeros propagation (needs separate ruleset, maybe jax.vjp improvement)
 
-def checkpoint_name3(name, x):
-  return CheckpointName(name, typeof(x))(x)
+def checkpoint_name3(name, x, fwd=False):
+  # The policy decides at trace time; the staged primitive carries the verdict
+  # rather than the name.
+  policy = current_policy()
+  if policy is None:
+    return x
+  case = pe.ensure_enum(policy(name_p, name=name))
+  if isinstance(case, pe.SaveableType):
+    return (CheckpointThisFwd if fwd else CheckpointThis)(typeof(x))(x)
+  elif isinstance(case, pe.Offloadable):
+    return (OffloadThisFwd if fwd else OffloadThis)(
+        typeof(x), src=case.src, dst=case.dst)(x)
+  return x
 
 def remat3(f=None, /, policy=None, static_argnums=(), static_argnames=(),
            prevent_cse=True):
@@ -1036,7 +1047,9 @@ def _remat3(f, *, policy, static_argnums, static_argnames, prevent_cse=True):
     dbg = api_util.debug_info(
         'remat3', f, args, kwargs, static_argnums=static_argnums,
         static_argnames=static_argnames)
-    jaxpr_, out_avals_ft = pe.trace_to_jaxpr(f, avals_ft, dbg)
+    with policy_context(policy):
+      jaxpr_, out_avals_ft = _trace_under_policy(f, current_policy(),
+                                                 avals_ft, dbg)
     jaxpr, consts = pe.separate_consts(jaxpr_)
     if isinstance(prevent_cse, bool):
       prevent_cse_ = prevent_cse
@@ -1048,6 +1061,13 @@ def _remat3(f, *, policy, static_argnums, static_argnames, prevent_cse=True):
     out_flat = RematTraced(jaxpr, policy, prevent_cse_)(*consts, *args_ft)
     return out_avals_ft.update(out_flat).unflatten()
   return decorator
+
+@weakref_lru_cache
+def _trace_under_policy(f, policy, avals_ft, dbg):
+  # Like pe.trace_to_jaxpr, but keyed on the (ambient, effective) policy too,
+  # since checkpoint_name reads it while f is traced.
+  del policy
+  return pe.trace_to_jaxpr_nocache(f, avals_ft, dbg)
 
 def _static_argnums(f, argnums, argnames) -> frozenset[int]:
   argnums = set(argnums)
@@ -1113,16 +1133,17 @@ class RematTraced(HiPrim):
     # TODO eval_jaxpr_p trace time
     self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
-                                        custom_vjp_rules=True)
     in_nzs = tuple(tree_leaves(nzs_in))
     out_nzs_cell = []
     def make_vjp(*xs):
       _, f_vjp = api.vjp(fwd2, *xs, in_nzs=in_nzs)
       out_nzs_cell.append(f_vjp.out_nzs)  # pyrefly: ignore[missing-attribute]
       return f_vjp
-    with config.mutable_array_checks(False):
-      traced_vjp = api.jit(make_vjp).trace(*primals)
+    with policy_context(self.policy):
+      primals_out, fwd2 = remat_transform(traced, *primals,
+                                          custom_vjp_rules=True)
+      with config.mutable_array_checks(False):
+        traced_vjp = api.jit(make_vjp).trace(*primals)
     used, rem = dce(traced_vjp, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
     if isinstance(self.prevent_cse, bool):
@@ -1162,16 +1183,17 @@ class RematTraced(HiPrim):
   def lin(self, nzs_in, *primals):
     self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
-                                        custom_vjp_rules=True)
     in_nzs = tuple(tree_leaves(nzs_in))
     out_nzs_cell = []
     def make_lin(*xs):
       _, f_jvp = api.linearize(fwd2, *xs, in_nzs=in_nzs)
       out_nzs_cell.append(f_jvp.out_nzs)  # pyrefly: ignore[missing-attribute]
       return f_jvp
-    with config.mutable_array_checks(False):
-      traced_lin = api.jit(make_lin).trace(*primals)
+    with policy_context(self.policy):
+      primals_out, fwd2 = remat_transform(traced, *primals,
+                                          custom_vjp_rules=True)
+      with config.mutable_array_checks(False):
+        traced_lin = api.jit(make_lin).trace(*primals)
     used, rem = dce(traced_lin, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
     out_nzs, = out_nzs_cell
@@ -1194,13 +1216,16 @@ class RematTraced(HiPrim):
                        self.prevent_cse)(*args), out_dims
 
   def remat(self, trace, *args):  # pyrefly: ignore[bad-param-name-override]
+    # Nested under another checkpoint's transform: that one's policy is ambient
+    # and governs here too, as in classic remat.
     traced = core.jaxpr_as_fun(self.jaxpr)
-    out, rem_ = remat_transform(trace.policy, traced, *args,
+    out, rem_ = remat_transform(traced, *args,
                                 custom_vjp_rules=trace.custom_vjp_rules)
     (jaxpr, in_tree, out_tree), (res,) = rem_.func.args, rem_.args
+    policy = current_policy()
     def rem(*args_):
       args_flat = tree_leaves_checked(in_tree, args_)
-      out_flat = RematTraced(jaxpr, trace.policy)(*res, *args_flat)
+      out_flat = RematTraced(jaxpr, policy)(*res, *args_flat)
       return tree_unflatten(out_tree, out_flat)
     return out, rem
 
@@ -1218,49 +1243,30 @@ class RematTraced(HiPrim):
     return (tuple(used_ins), tuple(used_outs_flat),
             RematTraced(new_jaxpr, self.policy, prevent_cse))
 
-class CheckpointName(HiPrim):
-  name: str
+class _IdentityPrim(HiPrim):
+  """Identity on one array. Subclasses customize only the remat rule."""
 
-  def __init__(self, name, aval):
+  def __init__(self, aval, **params):
     self.in_avals = aval,
     self.out_aval = aval
-    self.params = dict(name=name)
+    self.params = params
     super().__init__()
 
   def expand(self, x):  # pyrefly: ignore[bad-override]
     return x
 
-  def remat(self, trace, x):  # pyrefly: ignore[bad-override]
-    policy = trace.policy
-    x = CheckpointName(self.name, self.in_avals[0])(x)
-    if policy is None:
-      return x, lambda x: x  # full remat
-    case = pe.ensure_enum(policy(name_p, name=self.name))
-    if isinstance(case, pe.SaveableType):
-      return x, partial(primal_left_tangent_right, x)
-    elif isinstance(case, pe.Offloadable):
-      x_host = api.device_put(x, core.mem_kind_to_space(case.dst),
-                              may_alias=False)
-      src_space = core.mem_kind_to_space(case.src)
-      def rem(x_rem):
-        x_dev = api.device_put(x_host, src_space, may_alias=False)
-        return primal_left_tangent_right(x_dev, x_rem)
-      return x, rem
-    else:
-      return x, lambda x: x  # full remat
-
   def jvp(self, primals, tangents):
     (x,), (xdot,) = primals, tangents
-    return CheckpointName(self.name, self.in_avals[0])(x), xdot
+    return self(x), xdot
 
   def vjp_fwd(self, _nzs_in, x):  # type: ignore
-    return CheckpointName(self.name, self.in_avals[0])(x), None
+    return self(x), None
 
   def vjp_bwd_retval(self, _, g):
     return g,
 
   def lin(self, nzs_in, x):  # type: ignore
-    return CheckpointName(self.name, self.in_avals[0])(x), None
+    return self(x), None
 
   def linearized(self, _, g):  # type: ignore
     return g
@@ -1268,52 +1274,40 @@ class CheckpointName(HiPrim):
   def batch_dim_rule(self, axis_data, dims, /):
     return dims[0]
 
-class CheckpointNameFwd(HiPrim):
-  name: str
+class CheckpointThis(_IdentityPrim):
+  """Save the value as a residual; recompute only its tangent."""
+  def remat(self, _trace, x):  # pyrefly: ignore[bad-override]
+    x = self(x)
+    return x, partial(primal_left_tangent_right, x)
 
-  def __init__(self, name, aval):
-    self.in_avals = aval,
-    self.out_aval = aval
-    self.params = dict(name=name)
-    super().__init__()
+class CheckpointThisFwd(_IdentityPrim):
+  """Save the value as a residual and ignore the recomputation entirely."""
+  def remat(self, _trace, x):  # pyrefly: ignore[bad-override]
+    x = self(x)
+    return x, lambda _: x
 
-  def expand(self, x):  # pyrefly: ignore[bad-override]
-    return x
+def _offload(x, src, dst):
+  x_host = api.device_put(x, core.mem_kind_to_space(dst), may_alias=False)
+  src_space = core.mem_kind_to_space(src)
+  return lambda: api.device_put(x_host, src_space, may_alias=False)
 
-  def remat(self, trace, x):  # pyrefly: ignore[bad-override]
-    policy = trace.policy
-    x = CheckpointNameFwd(self.name, self.in_avals[0])(x)
-    if policy is None:
-      return x, lambda x: x  # full remat
-    case = pe.ensure_enum(policy(name_p, name=self.name))
-    if isinstance(case, pe.SaveableType):
-      return x, lambda _: x
-    elif isinstance(case, pe.Offloadable):
-      x_host = api.device_put(x, core.mem_kind_to_space(case.dst),
-                              may_alias=False)
-      src_space = core.mem_kind_to_space(case.src)
-      return x, lambda _: api.device_put(x_host, src_space, may_alias=False)
-    else:
-      return x, lambda x: x  # full remat
+class OffloadThis(_IdentityPrim):
+  """Like CheckpointThis, but the residual lives in ``dst`` memory."""
+  src: str
+  dst: str
+  def remat(self, _trace, x):  # pyrefly: ignore[bad-override]
+    x = self(x)
+    reload = _offload(x, self.src, self.dst)
+    return x, lambda x_rem: primal_left_tangent_right(reload(), x_rem)
 
-  def jvp(self, primals, tangents):
-    (x,), (xdot,) = primals, tangents
-    return CheckpointNameFwd(self.name, self.in_avals[0])(x), xdot
-
-  def vjp_fwd(self, _nzs_in, x):  # type: ignore
-    return CheckpointNameFwd(self.name, self.in_avals[0])(x), None
-
-  def vjp_bwd_retval(self, _, g):
-    return g,
-
-  def lin(self, nzs_in, x):  # type: ignore
-    return CheckpointNameFwd(self.name, self.in_avals[0])(x), None
-
-  def linearized(self, _, g):  # type: ignore
-    return g
-
-  def batch_dim_rule(self, axis_data, dims, /):
-    return dims[0]
+class OffloadThisFwd(_IdentityPrim):
+  """Like CheckpointThisFwd, but the residual lives in ``dst`` memory."""
+  src: str
+  dst: str
+  def remat(self, _trace, x):  # pyrefly: ignore[bad-override]
+    x = self(x)
+    reload = _offload(x, self.src, self.dst)
+    return x, lambda _: reload()
 
 class PrimalLeftTangentRight(HiPrim):
   def __init__(self, aval_x, aval__x):
@@ -1413,7 +1407,7 @@ class CustomRemat(HiPrim):
 
   def remat(self, trace, *args_flat):  # type: ignore
     args, kwargs = tree_unflatten(self._in_tree, args_flat)  # type: ignore
-    out_primal, res = self.f1(trace.policy, *args, **kwargs)
+    out_primal, res = self.f1(current_policy(), *args, **kwargs)
     out_primal_flat = tree_leaves_checked(self._out_tree, out_primal)  # type: ignore
     def rem_flat(*args_flat):
       args, kwargs = tree_unflatten(self._in_tree, args_flat)  # type: ignore

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -856,7 +856,7 @@ class CustomVJPTraced(HiPrim):
       fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, list(dyn_args), static_args))
     # custom_vjp_rules=False so that custom_vjp applications inside fwd hit
     # the early return above rather than recursively tracing their fwds.
-    (out, _), rem_ = remat.remat_transform(trace.policy, fwd, *dyn_args,
+    (out, _), rem_ = remat.remat_transform(fwd, *dyn_args,
                                            custom_vjp_rules=False)
     res = tuple(rem_.args[0])
     replay, statics = rem_.func, self.static_argnums

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -14,8 +14,10 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from functools import partial
 from collections.abc import Callable
+import threading
 
 from jax._src import core
 from jax._src import api_util
@@ -36,12 +38,43 @@ zip = safe_zip
 #  [ ] allow NotAvailable sentinels
 #  [ ] primal-output-to-residual forwarding
 
-def remat_transform(policy, f, *args, custom_vjp_rules):
+
+# The current remat policy is ambient (thread-local) state rather than an
+# attribute of RematTrace: it's read by checkpoint_name at trace time (to
+# decide whether to stage a CheckpointThis/OffloadThis) and by a few remat
+# rules (e.g. dot_general's) at transform time. The outermost policy_context
+# wins, so a checkpoint nested inside another one sees the enclosing policy,
+# as in classic remat.
+
+class _PolicyState(threading.local):
+  def __init__(self):
+    self.policy = None
+    self.active = False
+
+_policy_state = _PolicyState()
+
+@contextmanager
+def policy_context(policy):
+  """Make ``policy`` current, unless a policy is already current."""
+  if _policy_state.active:
+    yield
+    return
+  _policy_state.policy, _policy_state.active = policy, True
+  try:
+    yield
+  finally:
+    _policy_state.policy, _policy_state.active = None, False
+
+def current_policy():
+  return _policy_state.policy
+
+
+def remat_transform(f, *args, custom_vjp_rules):
   dbg = api_util.debug_info("remat", f, args, {})
   with core.take_current_trace() as parent_trace:
     jaxpr_trace = pe.DynamicJaxprTrace(None)
     jaxpr_trace.tag = core.TraceTag()
-    trace = RematTrace(parent_trace, jaxpr_trace, policy, custom_vjp_rules)
+    trace = RematTrace(parent_trace, jaxpr_trace, custom_vjp_rules)
     args_ft, _ = ft.flatten_args(*args).unpack()
     in_tracers = args_ft.map(
         lambda x: RematTracer(trace, x, jaxpr_trace.new_arg(typeof(x), None)))  # type: ignore # noqa F821
@@ -75,11 +108,10 @@ class RematTracer(core.Tracer['RematTrace']):
     self.tracer = jaxpr_tracer
 
 class RematTrace(core.Trace):
-  def __init__(self, parent_trace, jaxpr_trace, policy, custom_vjp_rules):
+  def __init__(self, parent_trace, jaxpr_trace, custom_vjp_rules):
     super().__init__()
     self.parent_trace = parent_trace
     self.jaxpr_trace = jaxpr_trace
-    self.policy = policy
     self.requires_low = False
     # flag to handle checkpoint_name calls in custom_vjp fwd w/o inf recursion
     self.custom_vjp_rules = custom_vjp_rules
@@ -134,13 +166,13 @@ class RematTrace(core.Trace):
                               out_trees=out_trees, symbolic_zeros=symbolic_zeros)
     return map(partial(RematTracer, self), out_primal, out_primal2)
 
-def remat_subtrace(f: Callable, tag: core.TraceTag, policy,
+def remat_subtrace(f: Callable, tag: core.TraceTag,
                    debug_info: core.DebugInfo, args, custom_vjp_rules):
   source_info = source_info_util.current()
   with core.take_current_trace() as parent_trace:
     rem_trace = pe.DynamicJaxprTrace(debug_info, auto_dce=True)
     rem_trace.tag = tag
-    trace = RematTrace(parent_trace, rem_trace, policy, custom_vjp_rules)
+    trace = RematTrace(parent_trace, rem_trace, custom_vjp_rules)
     tracers = [RematTracer(trace, x, rem_trace.new_arg(typeof(x), source_info))
                for x in args]
     with core.set_current_trace(trace, check_leaks=True):
@@ -174,21 +206,23 @@ reduce_precision_handlers: dict[type, Callable] = {}
 
 
 def remat_jaxpr(
-    jaxpr, policy, custom_vjp_rules, allow_fwds
+    jaxpr, custom_vjp_rules, allow_fwds
 ) -> tuple[core.Jaxpr, core.Jaxpr, list[int | None]]:
   n = len(jaxpr.outvars)
   if type(allow_fwds) is bool:
     allow_fwds = (allow_fwds,) * n
   assert len(allow_fwds) == n
-  return _remat_jaxpr(jaxpr, policy, custom_vjp_rules, tuple(allow_fwds))
+  return _remat_jaxpr(jaxpr, current_policy(), custom_vjp_rules,
+                      tuple(allow_fwds))
 
 @weakref_lru_cache
 def _remat_jaxpr(jaxpr, policy, custom_vjp_rules, allow_fwds):
+  del policy  # only a cache key; the remat rules read the ambient policy
   dbg = jaxpr.debug_info
   fwd_trace = pe.DynamicJaxprTrace(dbg)
   rem_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
   rem_trace.tag = core.TraceTag()
-  trace = RematTrace(fwd_trace, rem_trace, policy, custom_vjp_rules)
+  trace = RematTrace(fwd_trace, rem_trace, custom_vjp_rules)
   src = source_info_util.current()
 
   def new_arg(a):

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -997,7 +997,7 @@ def _cond_remat(trace, *args, branches, **params):
     # TODO(mattjj): allow forwarding (requires per-branch wiring to survive
     # the cross-branch residual merging below).
     jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+      jaxpr, trace.custom_vjp_rules, allow_fwds=False)
     num_res = len(fwds)
     branches_fwd.append(jaxpr_fwd)
     branches_rem.append(jaxpr_rem)

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1534,7 +1534,7 @@ def _scan_remat(trace, *args, jaxpr, ft_in, ft_out, **params):
   # TODO(mattjj): allow forwarding for ys outputs; carry outputs can't be
   # forwarded since residuals ride in the stacked ys position.
   jaxpr_fwd, jaxpr_rem_, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+      jaxpr, trace.custom_vjp_rules, allow_fwds=False)
   # Residuals ride along as extra ys (fwd scan) / extra xs (remnant scan).
   res_g = ft.nones(len(fwds))
   carry_out_g, ys_g = ft_out.unpack()

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6077,16 +6077,17 @@ dot_general_p = standard_primitive(
 )
 
 
-def _dot_general_remat(trace, lhs, rhs, **params):
+def _dot_general_remat(_trace, lhs, rhs, **params):
   from jax._src.ad_checkpoint import (
       DotsSaveable, OffloadDotWithNoBatchDims, primal_left_tangent_right)
   dot = partial(dot_general_p.bind, **params)
   out = dot(lhs, rhs)
-  if (isinstance(trace.policy, DotsSaveable) and
-      trace.policy(dot_general_p, typeof(lhs), typeof(rhs), **params)):
+  policy = remat.current_policy()
+  if (isinstance(policy, DotsSaveable) and
+      policy(dot_general_p, typeof(lhs), typeof(rhs), **params)):
     return out, lambda lhs, rhs: primal_left_tangent_right(out, dot(lhs, rhs))
-  if isinstance(trace.policy, OffloadDotWithNoBatchDims):
-    verdict = trace.policy(dot_general_p, typeof(lhs), typeof(rhs), **params)
+  if isinstance(policy, OffloadDotWithNoBatchDims):
+    verdict = policy(dot_general_p, typeof(lhs), typeof(rhs), **params)
     if isinstance(verdict, pe.Offloadable):
       from jax._src.api import device_put
       out_host = device_put(out, core.mem_kind_to_space(verdict.dst),

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1648,7 +1648,7 @@ ad.primitive_linearizations[jit_p] = _pjit_linearize
 
 def _pjit_remat(trace, *args, jaxpr, **params):
   jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=True)
+      jaxpr, trace.custom_vjp_rules, allow_fwds=True)
   num_res_out = sum(f is None for f in fwds)
   params_fwd, params_rem = _add_res_to_params(num_res_out, len(fwds), **params)
   primals_res_out = jit_p.bind(*args, jaxpr=jaxpr_fwd, **params_fwd)

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1852,7 +1852,7 @@ def _shard_map_remat(trace, shard_map_p, f, tracers, mesh, in_specs, check_vma,
 
   def f_fwd(*in_vals):
     res, ans_aux, rem_data = remat.remat_subtrace(
-        f, trace.tag, trace.policy, debug_info, in_vals,
+        f, trace.tag, debug_info, in_vals,
         custom_vjp_rules=trace.custom_vjp_rules)
     primals_out, out_specs = ans_aux.unpack_aux()
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7111,7 +7111,11 @@ class RematTest(jtu.JaxTestCase):
       return x
 
     res = saved_residuals(f, jnp.ones((3, 3)))
-    self.assertStartsWith(res[1][1], "named 'foo'")
+    self.assertStartsWith(res[1][1], self._named_residual_prefix('foo'))
+
+  def _named_residual_prefix(self, name):
+    # remat3's saved-value primitive doesn't carry the name.
+    return 'output of CheckpointThis' if config.remat3.value else f"named '{name}'"
 
   def test_name_pytree(self):
     policy = jax.checkpoint_policies.save_only_these_names('foo')
@@ -7123,7 +7127,7 @@ class RematTest(jtu.JaxTestCase):
       return x
 
     res = saved_residuals(f, jnp.ones((3, 3)))
-    self.assertStartsWith(res[1][1], "named 'foo'")
+    self.assertStartsWith(res[1][1], self._named_residual_prefix('foo'))
 
   def test_name_denylist(self):
     def f(x):
@@ -7211,7 +7215,11 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(res[3][0].shape, ())
     self.assertEqual(res[3][1], "from the argument y")
     self.assertEqual(res[4][0].shape, ())
-    self.assertStartsWith(res[4][1], "named 'z'")
+    if config.remat3.value:
+      # outside any checkpoint, remat3's checkpoint_name stages nothing
+      self.assertStartsWith(res[4][1], "output of sin")
+    else:
+      self.assertStartsWith(res[4][1], "named 'z'")
     self.assertEqual(res[5][0].shape, ())
 
   def test_saved_residuals_utility_jit(self):
@@ -8288,10 +8296,11 @@ class Remat3Test(RematTest):
     def body(x):
       return checkpoint_name(jnp.sin(x), 'y')
 
-    jaxpr = jax.jit(body).trace(1.).jaxpr
     policy = jax.checkpoint_policies.save_only_these_names('y')
-    fwd_jaxpr, _, fwds = remat_internal.remat_jaxpr(
-        jaxpr, policy, custom_vjp_rules=True, allow_fwds=True)
+    with remat_internal.policy_context(policy):
+      jaxpr = jax.jit(body).trace(1.).jaxpr
+      fwd_jaxpr, _, fwds = remat_internal.remat_jaxpr(
+          jaxpr, custom_vjp_rules=True, allow_fwds=True)
     self.assertEqual(fwds, [0])
     self.assertLen(fwd_jaxpr.outvars, len(jaxpr.jaxpr.outvars))
 

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2919,7 +2919,8 @@ class CustomVJPRemat3Test(jtu.JaxTestCase):
 
     policy = jax.checkpoint_policies.save_only_these_names('saved')
     res = saved_residuals(jax.remat(layer, policy=policy), jnp.arange(4.))
-    self.assertTrue(any("named 'saved'" in s for _, s in res),
+    # remat3's saved-value primitive doesn't carry the name
+    self.assertTrue(any('output of CheckpointThisFwd' in s for _, s in res),
                     msg=f'saved residuals: {[s for _, s in res]}')
 
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -43,7 +43,7 @@ from jax._src.util import safe_zip, safe_map, partition_list, merge_lists
 from jax._src.ad_checkpoint import saved_residuals
 from jax._src.mesh import AxisType, get_abstract_mesh, empty_concrete_mesh
 from jax._src.interpreters import partial_eval as pe
-from jax._src.interpreters.remat import remat_transform
+from jax._src.interpreters.remat import remat_transform, policy_context
 from jax._src import linear_util as lu
 from jax._src import tree_util
 from jax.custom_derivatives import SymbolicZero
@@ -1111,7 +1111,8 @@ class ShardMapTest(jtu.JaxTestCase):
       return z.sum()
 
     x = jax.device_put(jnp.arange(2.), jax.P('i'))
-    y1, f_ = remat_transform(policy, f, x, custom_vjp_rules=True)  # don't crash
+    with policy_context(policy):
+      y1, f_ = remat_transform(f, x, custom_vjp_rules=True)  # don't crash
     y2 = f_(x)
     self.assertAllClose(y1, y2, check_dtypes=False)
 


### PR DESCRIPTION
One change in behavior is that "outer policy wins" now means "outermost dynamically enclosing remat policy" rather than "outermost dynamically enclosing remat policy *within the innermost vjp*". If we want to restore the latter behavior, we can just have vjp (and linearize) reset the policy context.

Another included regression is `print_saved_residuals` doesn't include the name. We could fix that by having names be included for debug purposes, not load-bearing.