### PR TITLE
[pallas] hlo_interpreter: Fix dropped writes to aliased outputs

### DIFF
--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -400,6 +400,28 @@ def pallas_call_hlo_interpret(
     # Base case is always one iteration when grid is ()
     num_iterations = 1
 
+  # For each aliased input/output pair, determine statically (from the kernel
+  # jaxpr's effects, which include writes made inside loop and branch bodies)
+  # whether the kernel writes through the input ref and/or the output ref.
+  # Note that we cannot infer this from the discharged jaxpr's outputs: a ref
+  # that is merely *read* inside e.g. a loop body or a `run_scoped` is still
+  # threaded through the discharged region and comes back as a new value.
+  written_refs = {
+      eff.input for eff in jaxpr.effects
+      if isinstance(eff, (state.WriteEffect, state.AccumEffect))
+  }
+  # jaxpr.invars: [*scalar_prefetch, *consts, *inputs, *outputs, *scratch].
+  # `in_idx` indexes into `args` (a prefix of the invars) and `out_idx` indexes
+  # into the outputs.
+  alias_input_written = {
+      in_idx: jaxpr.invars[in_idx] in written_refs
+      for in_idx, _ in input_output_aliases
+  }
+  alias_output_written = {
+      out_idx: jaxpr.invars[len(args) + out_idx] in written_refs
+      for _, out_idx in input_output_aliases
+  }
+
   # The scan carry: (i, loop_idx, *consts, *ins, *outs, *scratch)
   # i:int32 is the iteration index
   # loop_idx: tuple[int32] are the program ids for each grid axis
@@ -457,8 +479,8 @@ def pallas_call_hlo_interpret(
     for in_idx, out_idx in input_output_aliases:
       in_idx_adj = in_idx - len(scalars)
       out_idx_adj = len(block_args) + out_idx
-      input_modified = out_inout[in_idx_adj] is not in_blocks[in_idx_adj]
-      output_modified = out_inout[out_idx_adj] is not in_blocks[out_idx_adj]
+      input_modified = alias_input_written[in_idx]
+      output_modified = alias_output_written[out_idx]
       if input_modified and not output_modified:
         out_carry[out_idx_adj] = out_carry[in_idx_adj]
       elif output_modified and not input_modified:

--- a/tests/pallas/tpu_pallas_test.py
+++ b/tests/pallas/tpu_pallas_test.py
@@ -5456,6 +5456,41 @@ class MiscellaneousTest(ptu.PallasTPUTest):
     )(x)
     np.testing.assert_array_equal(out, x)
 
+  @parameterized.parameters('fori_loop', 'run_scoped')
+  def test_aliased_output_write_with_input_read_in_nested_scope(self, scope):
+    # Reads the aliased input only inside a nested scope (a loop body or a
+    # run_scoped) and writes the aliased output. Regression test for the HLO
+    # interpreter, which used to discard the output writes in this case.
+    if not self.INTERPRET and not jtu.is_device_tpu_at_least(4):
+      self.skipTest('DMAs not supported on TPU generations <= 3')
+
+    def kernel(x_hbm_ref, o_hbm_ref, vmem_ref, sem):
+      i = pl.program_id(0)
+      if scope == 'fori_loop':
+        def body(_, carry):
+          pltpu.async_copy(x_hbm_ref.at[i], vmem_ref, sem).wait()
+          return carry
+        lax.fori_loop(0, 1, body, None)
+      else:
+        pltpu.sync_copy(x_hbm_ref.at[i], vmem_ref)
+      vmem_ref[...] += 1
+      pltpu.async_copy(vmem_ref, o_hbm_ref.at[i], sem).wait()
+
+    x = jnp.arange(2 * 8 * 128, dtype=jnp.int32).reshape((2, 8, 128))
+    y = self.pallas_call(
+        kernel,
+        grid=(2,),
+        in_specs=[pl.BlockSpec(memory_space=pl.ANY)],
+        out_specs=pl.BlockSpec(memory_space=pl.ANY),
+        out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+        scratch_shapes=[
+            pltpu.VMEM((8, 128), jnp.int32),
+            pltpu.SemaphoreType.DMA,
+        ],
+        input_output_aliases={0: 0},
+    )(x)
+    np.testing.assert_array_equal(y, x + 1)
+
 
 class MiscellaneousInterpretTest(MiscellaneousTest):
   INTERPRET: bool = True


### PR DESCRIPTION
When a kernel with `input_output_aliases` only *read* the aliased input inside a nested scope (a `fori_loop` body, a `run_scoped`, `pltpu.sync_copy`, `emit_pipeline`, ...) and wrote the aliased output, `interpret=True` returned the untouched input: every write to the output was discarded.

The per-grid-step synchronization of aliased carry buffers decided whether each side of an aliased pair had been written by comparing object identity of the block values before and after evaluating the discharged kernel jaxpr. That is not a reliable signal: state discharge threads every ref a loop body or `run_scoped` closes over through the region, so a ref that was merely read also comes back as a new value. With both sides then classified as "modified", the input carry was copied over the output carry.

Instead, determine once, from the kernel jaxpr's Write/Accum effects (which cover writes nested in loop and branch bodies), whether the kernel writes through the aliased input ref and/or the aliased output ref, and use that in place of the identity check. The synchronization policy itself is unchanged.

Adds a regression test that reads the aliased input inside a `fori_loop` / `run_scoped` and writes the aliased output; it runs in interpret mode on CPU and on TPU.