### PR TITLE
Expose local_to_global_shape in public API

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -154,7 +154,8 @@ from jax._src.sharding_impls import (
     NamedSharding as NamedSharding,
     make_mesh as make_mesh,
     set_mesh as set_mesh,
-    get_mesh as get_mesh
+    get_mesh as get_mesh,
+    local_to_global_shape as local_to_global_shape,
 )
 from jax._src.mesh import (
     use_abstract_mesh as use_abstract_mesh,

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -977,8 +977,7 @@ def make_array_from_process_local_data(
 def _array_from_process_local_data(
     local_data: np.ndarray, sharding: Sharding,
     global_shape: Shape | None = None) -> ArrayImpl:
-  # TODO(sandler): consider supporting partially specified global_shape or
-  # making local_to_global_shape available in the api.
+  # TODO(sandler): consider supporting partially specified global_shape
   local_shape = local_data.shape
   if global_shape is None:
     global_shape = local_to_global_shape(sharding, local_shape)  # pyrefly: ignore[bad-assignment]

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -689,10 +689,13 @@ def local_to_global_shape(
       global_shape = (None, None)
 
   Args:
-    local_shape: global shape of the tensor.
+    sharding: The sharding of the global tensor.
+    local_shape: The shape of the tensor local to the current process.
 
   Returns:
-    global_shape with Nones in non-uniform dimensions.
+    The global shape, with None for dimensions whose global size cannot
+    be computed.
+
   """
 
   global_shape : list[int | None] = [None] * len(local_shape)

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -20,10 +20,11 @@ import dataclasses
 from absl import logging
 from absl.testing import absltest
 from absl.testing import parameterized
+import jax
 from jax._src import mesh as mesh_lib
 from jax._src import mesh_utils
 from jax._src import test_util as jtu
-from jax._src.sharding_impls import NamedSharding, PartitionSpec, local_to_global_shape
+from jax._src.sharding_impls import NamedSharding, PartitionSpec
 from jax.sharding import Mesh
 import numpy as np
 
@@ -400,13 +401,19 @@ class MeshUtilsTest(jtu.JaxTestCase):
                                            allow_split_physical_axes=True)
       mesh = mesh_lib.Mesh(mesh, ('a', 'b', 'c'))
       sharding = NamedSharding(mesh, PartitionSpec('a', 'b', 'c'))
-      computed_global_shape = local_to_global_shape(sharding, (1, 1, 1))
+      computed_global_shape = jax.local_to_global_shape(
+          sharding=sharding,
+          local_shape=(1, 1, 1),
+      )
       self.assertFalse(
           np.any([x is None for x in computed_global_shape]),
           f'{mesh_shape=}, {computed_global_shape=} is not uniform')
 
       sharding = NamedSharding(mesh, PartitionSpec(('a', 'c',), 'b'))
-      computed_global_shape = local_to_global_shape(sharding, (1, 1, 1))
+      computed_global_shape = jax.local_to_global_shape(
+          sharding=sharding,
+          local_shape=(1, 1, 1),
+      )
       self.assertFalse(
           np.any([x is None for x in computed_global_shape]),
           f'{mesh_shape=}, {computed_global_shape=} is not uniform')


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->
## Summary

Expose `local_to_global_shape` in the public `jax` API.

- Export `local_to_global_shape` from `jax/__init__.py`.
- Update its docstring to accurately describe `sharding` and `local_shape`.
- Update the existing mesh utility tests to exercise the public `jax.local_to_global_shape` API.
- Fixes #38889


## Testing

- `pre-commit run --all-files` — passed
- `pytest tests/mesh_utils_test.py` — 88 passed
- `git diff --check` — passed

`tests/api_test.py` was also run; it had one failure in `BackendsTest.test_no_backend_warning_on_cpu_if_platform_specified` due to the local environment falling back to CPU because CUDA-enabled `jaxlib` is not installed.