### PR TITLE
Add step argument to lax.fori_loop for range-style iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * New features
   * Added {func}`jax.export.symbolic_dim_bounds` for querying conservative
     bounds on symbolic dimension expressions ({jax-issue}`#40006`).
+  * {func}`jax.lax.fori_loop` now accepts a `step` argument, giving it
+    `range(lower, upper, step)` semantics including negative steps for
+    reverse iteration ({jax-issue}`#2016`).
   * {func}`jax.distributed.initialize` can now secure the coordination service
     with mutual TLS via the new `mtls_cert_file`, `mtls_key_file`,
     `mtls_ca_file`, `mtls_peer_uri_prefix` and `verify_secure_credentials`

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2507,19 +2507,26 @@ def _pred_bcast_select_hlo(ctx,
 
 ### fori_loop
 
-def _fori_cond_fun(loop_carry):
+def _fori_trip_count(lower, upper, step):
+  """Number of iterations of ``range(lower, upper, step)``."""
+  # Integer ceil division, not float, to avoid rounding on large bounds.
+  return max(0, -(-(upper - lower) // step))
+
+def _fori_cond_fun(loop_carry, step=1):
   i, upper, _ = loop_carry
-  return lax.lt(i, upper)
+  # `upper` is the exclusive stop bound in both directions.
+  return lax.lt(i, upper) if step > 0 else lax.gt(i, upper)
 
 @weakref_lru_cache
-def _fori_body_fun(body_fun: Callable, body_fun_dbg: core.DebugInfo) -> Callable:
+def _fori_body_fun(body_fun: Callable, body_fun_dbg: core.DebugInfo,
+                   step: int = 1) -> Callable:
   body_fun_ref = weakref.ref(body_fun)
 
   def while_body_fun(loop_carry):
     i, upper, x = loop_carry
     body_fun = body_fun_ref()
     assert body_fun is not None
-    return lax.add(i, lax._const(i, 1)), upper, body_fun(i, x)
+    return lax.add(i, lax._const(i, step)), upper, body_fun(i, x)
   if body_fun_dbg.arg_names is not None:
     arg_names = (body_fun_dbg.arg_names[0],
                  "",  # upper,
@@ -2532,20 +2539,21 @@ def _fori_body_fun(body_fun: Callable, body_fun_dbg: core.DebugInfo) -> Callable
   return while_body_fun
 
 @weakref_lru_cache
-def _fori_scan_body_fun(body_fun: Callable, body_fun_dbg: core.DebugInfo) -> Callable:
+def _fori_scan_body_fun(body_fun: Callable, body_fun_dbg: core.DebugInfo,
+                        step: int = 1) -> Callable:
   body_fun_ref = weakref.ref(body_fun)
   def scanned_fun(loop_carry, _):
     i, x = loop_carry
     body_fun = body_fun_ref()
     assert body_fun is not None
-    return (i + 1, body_fun(i, x)), None
+    return (i + step, body_fun(i, x)), None
   api_util.save_wrapped_fun_debug_info(
       scanned_fun, body_fun_dbg._replace(result_paths=None))
   return scanned_fun
 
 @partial(api_boundary, repro_api_name="jax.lax.fori_loop")
 def fori_loop(lower, upper, body_fun, init_val,
-              *, unroll: int | bool | None = None):
+              *, unroll: int | bool | None = None, step: int = 1):
   """Loop from ``lower`` to ``upper`` by reduction to :func:`jax.lax.while_loop`.
 
   The `Haskell-like type signature`_ in brief is
@@ -2556,14 +2564,15 @@ def fori_loop(lower, upper, body_fun, init_val,
 
   The semantics of ``fori_loop`` are given by this Python implementation::
 
-    def fori_loop(lower, upper, body_fun, init_val):
+    def fori_loop(lower, upper, body_fun, init_val, *, step=1):
       val = init_val
-      for i in range(lower, upper):
+      for i in range(lower, upper, step):
         val = body_fun(i, val)
       return val
 
-  As the Python version suggests, setting ``upper <= lower`` will produce no
-  iterations. Negative or custom increments are not supported.
+  As the Python version suggests, an empty range produces no iterations: with a
+  positive ``step`` that means ``upper <= lower``, and with a negative ``step``
+  it means ``upper >= lower``.
 
   Unlike that Python version, ``fori_loop`` is implemented in terms of either a
   call to :func:`jax.lax.while_loop` or a call to :func:`jax.lax.scan`. If the
@@ -2596,6 +2605,10 @@ def fori_loop(lower, upper, body_fun, init_val,
       boolean is provided, it will determine if the loop is completely unrolled
       (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
       This argument is only applicable if the loop bounds are statically known.
+    step: an optional nonzero Python ``int`` giving the loop index increment,
+      following :py:func:`range` semantics, so the index passed to ``body_fun``
+      on iteration ``k`` is ``lower + k * step``. Unlike ``lower`` and
+      ``upper``, it must be a concrete Python ``int``.
 
   Returns:
     Loop value from the final iteration, of type ``a``.
@@ -2604,6 +2617,12 @@ def fori_loop(lower, upper, body_fun, init_val,
   """
   if not callable(body_fun):
     raise TypeError("lax.fori_loop: body_fun argument should be callable.")
+  # `bool` is a subclass of `int`, so guard it explicitly.
+  if isinstance(step, bool) or not isinstance(step, int):
+    raise TypeError("lax.fori_loop: step argument should be a nonzero Python "
+                    f"int, got {step!r}.")
+  if step == 0:
+    raise ValueError("lax.fori_loop: step argument should be nonzero.")
 
   # TODO(phawkins): perhaps do more type checking here, better error messages.
   lower_dtype = lax.dtype(lower)
@@ -2648,11 +2667,11 @@ def fori_loop(lower, upper, body_fun, init_val,
   if use_scan:
     if unroll is None:
       unroll = False
-    length = max(upper_ - lower_, 0)
+    length = _fori_trip_count(lower_, upper_, step)
     if config.disable_jit.value and length == 0:
       # non-jit implementation of scan does not support length=0
       return init_val
-    scan_body = _fori_scan_body_fun(body_fun, body_fun_dbg)
+    scan_body = _fori_scan_body_fun(body_fun, body_fun_dbg, step)
     (_, result), _ = scan(
         scan_body,
         (lower_, init_val),
@@ -2669,8 +2688,8 @@ def fori_loop(lower, upper, body_fun, init_val,
     lower = lax.convert_element_type(lower, dtype)
   if upper_dtype != dtype:
     upper = lax.convert_element_type(upper, dtype)
-  while_body_fun = _fori_body_fun(body_fun, body_fun_dbg)
-  _, _, result = while_loop(_fori_cond_fun, while_body_fun,
+  while_body_fun = _fori_body_fun(body_fun, body_fun_dbg, step)
+  _, _, result = while_loop(partial(_fori_cond_fun, step=step), while_body_fun,
                             (lower, upper, init_val))
   return result
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -94,11 +94,47 @@ WHILE_LOOP_IMPLS = [
     (while_loop_new_checkpoint, 'new_checkpoint'),
 ]
 
+# (lower, upper, step) triples spanning both directions, strides that do and do
+# not divide the span, and every empty range.
+FORI_STEP_CASES = [
+    (0, 5, 1),
+    (5, 0, -1),
+    (0, 10, 3),
+    (0, 7, 3),
+    (0, 9, 3),
+    (10, 0, -3),
+    (5, 0, 1),      # empty
+    (0, 5, -1),     # empty
+    (3, 3, 1),      # zero length
+    (3, 3, -1),     # zero length
+    (0, 1, 100),    # single iteration
+    (0, -1, -100),  # single iteration
+    (-5, 5, 2),
+    (5, -5, -2),
+]
+
+# `fori_loop` lowers to `scan` when both bounds are concrete and to `while_loop`
+# otherwise; the second entry passes the bounds as jit arguments to force it.
+FORI_PATHS = [
+    ("scan", lambda lower, upper, body, init, step:
+        lax.fori_loop(lower, upper, body, init, step=step)),
+    ("while", lambda lower, upper, body, init, step:
+        jax.jit(lambda lo, up, v: lax.fori_loop(lo, up, body, v, step=step))(
+            lower, upper, init)),
+]
+
 
 def while_loop_reference(cond, body, carry):
   while cond(carry):
     carry = body(carry)
   return carry
+
+
+def fori_loop_reference(lower, upper, body, init, step=1):
+  val = init
+  for i in range(lower, upper, step):
+    val = body(i, val)
+  return val
 
 
 def scan_reference(f, init, xs):
@@ -730,6 +766,148 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertAllClose(should_raise_wo_jit(), 0., check_dtypes=False)
     with jax.disable_jit():
       self.assertRaises(ValueError, should_raise_wo_jit)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{path}_{lower=}_{upper=}_{step=}",
+       "run": run, "lower": lower, "upper": upper, "step": step}
+      for path, run in FORI_PATHS
+      for lower, upper, step in FORI_STEP_CASES
+  )
+  def testForiLoopStep(self, run, lower, upper, step):
+    """`step` must match `range(lower, upper, step)` on both lowerings."""
+    # Accumulating the index, not counting, so that a body receiving the loop
+    # counter instead of the index fails here.
+    body = lambda i, val: val + i
+    expected = fori_loop_reference(lower, upper, body, 0, step)
+    self.assertEqual(int(run(lower, upper, body, 0, step)), expected)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{path}_{step=}", "run": run, "step": step}
+      for path, run in FORI_PATHS
+      for step in (1, -1, 3, -3)
+  )
+  def testForiLoopStepEmptyRangeRunsNoIterations(self, run, step):
+    """An empty range must run zero iterations and return init untouched.
+
+    `scan` traces `body_fun` even when `length == 0`, so this asserts on the
+    executed iteration count rather than on trace-time calls.
+    """
+    lower, upper = (5, 0) if step > 0 else (0, 5)
+    self.assertEqual(list(range(lower, upper, step)), [])
+
+    init = jnp.float32(10)
+    body = lambda i, val: val + i + 1.
+    self.assertEqual(run(lower, upper, body, init, step), init)
+
+  def testForiLoopStepTakesScanPathWhenBoundsConcrete(self):
+    """Concrete bounds must still lower to `scan`, which is differentiable."""
+    jaxpr = jax.make_jaxpr(
+        lambda x: lax.fori_loop(5, 0, lambda i, v: v * 2., x, step=-1))(1.)
+    prims = {eqn.primitive.name for eqn in jaxpr.eqns}
+    self.assertIn("scan", prims)
+    self.assertNotIn("while", prims)
+
+  def testForiLoopStepLargeTripCount(self):
+    """Trip count must use integer math, which float ceil would round."""
+    lower, upper, step = 0, 10 ** 7, 3
+    expected = len(range(lower, upper, step))
+    count = lax.fori_loop(lower, upper, lambda i, v: v + 1, 0, step=step)
+    self.assertEqual(int(count), expected)
+
+  def testForiLoopStepZero(self):
+    with self.assertRaisesRegex(ValueError, "step argument should be nonzero"):
+      lax.fori_loop(0, 5, lambda i, v: v, 0, step=0)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{step=}", "step": step}
+      for step in (True, False, 2.0, "2")
+  )
+  def testForiLoopStepNotAnInt(self, step):
+    # `bool` subclasses `int`, so `step=True` must not be read as `step=1`.
+    with self.assertRaisesRegex(TypeError, "step argument should be"):
+      lax.fori_loop(0, 5, lambda i, v: v, 0, step=step)
+
+  def testForiLoopStepTracedStepRejected(self):
+    """A traced step has no known sign, so its comparison cannot be chosen."""
+    with self.assertRaisesRegex(TypeError, "step argument should be"):
+      lax.fori_loop(0, 5, lambda i, v: v, 0, step=jnp.int32(2))
+
+    with self.assertRaisesRegex(TypeError, "step argument should be"):
+      jax.jit(lambda s: lax.fori_loop(0, 5, lambda i, v: v, 0, step=s))(2)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{step=}", "step": step} for step in (1, -1, 2, -2)
+  )
+  def testForiLoopStepGrad(self, step):
+    """Reverse-mode autodiff through the `scan` lowering."""
+    lower, upper = (0, 5) if step > 0 else (5, 0)
+    body = lambda i, val: val * (i + 1.)
+    f = lambda x: lax.fori_loop(lower, upper, body, x, step=step)
+    ref = lambda x: fori_loop_reference(lower, upper, body, x, step)
+
+    self.assertAllClose(f(2.), ref(2.), check_dtypes=False)
+    self.assertAllClose(jax.grad(f)(2.), jax.grad(ref)(2.), check_dtypes=False)
+    jtu.check_grads(f, (2.,), order=2, modes=["fwd", "rev"])
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{step=}", "step": step} for step in (1, -1, 2, -2)
+  )
+  def testForiLoopStepBatched(self, step):
+    lower, upper = (0, 6) if step > 0 else (6, 0)
+    body = lambda i, val: val + i
+    f = lambda init: lax.fori_loop(lower, upper, body, init, step=step)
+    xs = jnp.arange(4, dtype=jnp.float32)
+    expected = jnp.stack(
+        [fori_loop_reference(lower, upper, body, x, step) for x in xs])
+    self.assertAllClose(jax.vmap(f)(xs), expected, check_dtypes=False)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{path}_x64={x64}_{step=}",
+       "run": run, "x64": x64, "step": step}
+      for path, run in FORI_PATHS
+      for x64 in (False, True)
+      for step in (1, -1, 3, -3)
+  )
+  def testForiLoopStepIndexDtype(self, run, x64, step):
+    """The index dtype must follow the x64 setting.
+
+    Asserts dtype only, since weak_type already differs between the two
+    lowerings independently of `step`.
+    """
+    with config.enable_x64(x64):
+      expected_dtype = jnp.dtype(jnp.int64 if x64 else jnp.int32)
+      lower, upper = (0, 6) if step > 0 else (6, 0)
+
+      seen = []
+      def body(i, val):
+        seen.append(jnp.asarray(i).dtype)
+        return val + i
+
+      run(lower, upper, body, 0, step)
+      self.assertEqual(seen[-1], expected_dtype)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{step=}_{unroll=}", "step": step, "unroll": unroll}
+      for step in (1, -1, 2, -2)
+      for unroll in (False, True, 2)
+  )
+  def testForiLoopStepUnroll(self, step, unroll):
+    """`unroll` must keep working alongside a non-unit step."""
+    lower, upper = (0, 8) if step > 0 else (8, 0)
+    body = lambda i, val: val + i
+    expected = fori_loop_reference(lower, upper, body, 0, step)
+    actual = lax.fori_loop(lower, upper, body, 0, step=step, unroll=unroll)
+    self.assertEqual(int(actual), expected)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{lower=}_{upper=}", "lower": lower, "upper": upper}
+      for lower, upper in ((0, 5), (0, 0), (5, 0), (-3, 3))
+  )
+  def testForiLoopDefaultStepUnchanged(self, lower, upper):
+    """Calls that omit `step` must be unaffected."""
+    body = lambda i, val: val + i
+    expected = fori_loop_reference(lower, upper, body, 0)
+    self.assertEqual(int(lax.fori_loop(lower, upper, body, 0)), expected)
 
   def testCond(self):
     def fun(x):


### PR DESCRIPTION
Fixes #2016 

This PR adds an additional optional parameter step argument to the jax.lax.fori_loop giving it python's range(lower, upper, step) structure. It now also supports reverse iteration as well as jumps/strides. 

step parameter defaults to 1. This makes sure there is no regression from the current behaviour. I have used a python int. 
So, I can use its sign to select the loop condition. The scan-vs-while loop lowering is the same, so reverse loops with concrete bounds still lower to scan and hence are differentiable.

I have added new tests to ensure step parameter works and covers a wide variety of cases. 

I ran the full suite of tests and all the tests pass on my MacOS machine.
