### PR TITLE
Pass dimension variable values to composite decompositions

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1984,7 +1984,10 @@ def _composite_lowering(
     if v is not None:
       composite_attrs[k] = mlir.ir_attribute(v)
   symbol_name = func_op.name.value
-  flat_args, _ = mlir.ir_tree_registry.flatten(const_arg_values + args)
+  # lower_jaxpr_to_fun adds dim_var_values to the decomposition. The same
+  # variables must be added to the composite.
+  flat_args, _ = mlir.ir_tree_registry.flatten(
+      (*ctx.dim_var_values, *const_arg_values, *args))
   return hlo.CompositeOp(
       func_op.type.results,
       flat_args,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -5138,6 +5138,48 @@ class CompositeTest(jtu.JaxTestCase):
         '-> (tensor<f32>, tensor<f32>, tensor<f32>)', mlir_module)
     self.assertIn('return %arg0, %arg1, %arg2 : tensor<f32>, tensor<f32>, tensor<f32>', mlir_module)
 
+  def test_composite_with_symbolic_shapes(self):
+    @partial(lax.composite, name="my.square")
+    def my_square(x):
+      return x * x
+
+    exp = export.export(jax.jit(my_square))(
+        jax.ShapeDtypeStruct(export.symbolic_shape("b"), jnp.float32))
+    mlir_module = str(exp.mlir_module())
+    # The decomposition takes the dimension variable as its first argument, so
+    # the composite must pass it too.
+    self.assertRegex(
+        mlir_module,
+        r'stablehlo.composite "my.square" %arg0, %arg1 '
+        r'\{decomposition = @my.square\} : '
+        r'\(tensor<i..>, tensor<\?xf32>\) -> tensor<\?xf32>')
+    self.assertRegex(
+        mlir_module,
+        r'@my.square\(%arg0: tensor<i..>.*jax.global_constant = "b".*, '
+        r'%arg1: tensor<\?xf32>.*\) -> tensor<\?xf32>')
+
+  def test_composite_with_multiple_platforms(self):
+    @partial(lax.composite, name="my.square")
+    def my_square(x):
+      return x * x
+
+    x = jnp.arange(4, dtype=jnp.float32)
+    exp = export.export(jax.jit(my_square), platforms=("cpu", "tpu"))(x)
+    mlir_module = str(exp.mlir_module())
+    # Multi-platform lowering adds a platform index argument to every function,
+    # including the decomposition, so the composite must pass it too.
+    self.assertRegex(
+        mlir_module,
+        r'stablehlo.composite "my.square" %arg0, %arg1 '
+        r'\{decomposition = @my.square\} : '
+        r'\(tensor<i..>, tensor<4xf32>\) -> tensor<4xf32>')
+    self.assertRegex(
+        mlir_module,
+        r'@my.square\(%arg0: tensor<i..>.*jax.global_constant = "_platform_index".*, '
+        r'%arg1: tensor<4xf32>.*\) -> tensor<4xf32>')
+    x_cpu = jax.device_put(x, jax.devices("cpu")[0])
+    self.assertArraysEqual(exp.call(x_cpu), x * x)
+
   def test_composite_jvp(self):
     @partial(lax.composite, name="my.square")
     def my_square(x):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -5139,6 +5139,8 @@ class CompositeTest(jtu.JaxTestCase):
     self.assertIn('return %arg0, %arg1, %arg2 : tensor<f32>, tensor<f32>, tensor<f32>', mlir_module)
 
   def test_composite_with_symbolic_shapes(self):
+    # Executing this export requires StableHLO shape refinement support for
+    # composite decompositions with dynamic shapes (see #40486).
     @partial(lax.composite, name="my.square")
     def my_square(x):
       return x * x
@@ -5157,6 +5159,23 @@ class CompositeTest(jtu.JaxTestCase):
         mlir_module,
         r'@my.square\(%arg0: tensor<i..>.*jax.global_constant = "b".*, '
         r'%arg1: tensor<\?xf32>.*\) -> tensor<\?xf32>')
+
+  def test_composite_with_symbolic_shapes_execution(self):
+    @partial(lax.composite, name="my.square")
+    def my_square(x):
+      return x * x
+
+    # This decomposition accepts the enclosing export's dimension variables,
+    # but returns a scalar value so that it does not require shape refinement
+    # to execute
+    def f(x):
+      return my_square(x.sum())
+
+    exp = export.export(jax.jit(f))(
+        jax.ShapeDtypeStruct(export.symbolic_shape("b"), jnp.float32))
+    for b in (3, 5):
+      x = jnp.arange(b, dtype=jnp.float32)
+      self.assertArraysEqual(exp.call(x), x.sum() ** 2)
 
   def test_composite_with_multiple_platforms(self):
     @partial(lax.composite, name="my.square")


### PR DESCRIPTION
`lower_jaxpr_to_fun` gives every lowered function the dimension variable values as leading arguments. Under multi-platform lowering the platform index is one of them. `_composite_lowering` built the `stablehlo.composite` from the constants and array operands only, so under shape polymorphism or multi-platform export the operand count did not match the decomposition and the module failed verification with
"has 1 operand(s), but decomposition has 2".

Pass `ctx.dim_var_values` first, as `mlir.call_lowering` does.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->