### PR TITLE
fix: use compute_80 PTX for Ampere to support Jetson Orin (sm_87)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -198,7 +198,7 @@ common:cuda_v12 --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.9"
 common:cuda_v12 --repo_env=HERMETIC_NCCL_VERSION="2.30.7"
 # "sm" means we emit only cubin, which is forward compatible within a GPU generation.
 # "compute" means we emit both cubin and PTX, which is larger but also forward compatible to future GPU generations.
-common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,sm_101,compute_120"
+common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,compute_80,sm_90,sm_100,sm_101,compute_120"
 
 common:cuda_v13 --repo_env=HERMETIC_CUDA_VERSION="13.0.0"
 common:cuda_v13 --repo_env=HERMETIC_CUDNN_VERSION="9.12.0"


### PR DESCRIPTION
Replace sm_80 with compute_80 in cuda_v12 HERMETIC_CUDA_COMPUTE_CAPABILITIES.

The sm_80 cubin is not forward-compatible with sm_87 (Jetson Orin) or sm_86/sm_89, causing 'no kernel image is available for execution on the device' errors. Using compute_80 emits PTX that is JIT-compiled at runtime for any Ampere-family GPU (sm_80, sm_86, sm_87, sm_89).

This also benefits other Ampere GPUs like the RTX 3060/3070/3080 (sm_86) and RTX 4090 mobile (sm_89) that were previously only covered by falling back to the sm_80 cubin, which may not work on all devices.

Fixes jax-ml/jax#40487

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->