### PR TITLE
fix: pass dim_var_values in composite lowering for shape polymorphism

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1984,7 +1984,8 @@ def _composite_lowering(
     if v is not None:
       composite_attrs[k] = mlir.ir_attribute(v)
   symbol_name = func_op.name.value
-  flat_args, _ = mlir.ir_tree_registry.flatten(const_arg_values + args)
+  flat_args, _ = mlir.ir_tree_registry.flatten(
+      ctx.dim_var_values + const_arg_values + args)
   return hlo.CompositeOp(
       func_op.type.results,
       flat_args,


### PR DESCRIPTION
Include ctx.dim_var_values as leading operands of stablehlo.CompositeOp in _composite_lowering. The decomposition function produced by lower_jaxpr_to_fun / lower_called_computation prepends global constant arguments (dimension variables for symbolic shapes, _platform_index for multi-platform export) to every function signature. The composite op must pass those same leading arguments so that its operand count matches the decomposition.

Without this fix, lax.composite raises a StableHLO verification error ('has N operand(s), but decomposition has N+M') whenever symbolic shapes or multi-platform export are used.

This mirrors how call_lowering, compute_on, pjit, and shard_map all prepend dim_var_values when calling lowered functions.

Fixes jax-ml/jax#40486

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->