### PR TITLE
Add Orin SM arch (sm_87) to CUDA 12 build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -198,7 +198,7 @@ common:cuda_v12 --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.9"
 common:cuda_v12 --repo_env=HERMETIC_NCCL_VERSION="2.30.7"
 # "sm" means we emit only cubin, which is forward compatible within a GPU generation.
 # "compute" means we emit both cubin and PTX, which is larger but also forward compatible to future GPU generations.
-common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,sm_101,compute_120"
+common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_87,sm_90,sm_100,sm_101,compute_120"
 
 common:cuda_v13 --repo_env=HERMETIC_CUDA_VERSION="13.0.0"
 common:cuda_v13 --repo_env=HERMETIC_CUDNN_VERSION="9.12.0"


### PR DESCRIPTION
what has been changed:

```diff
-common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,sm_101,compute_120"
+common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_87,sm_90,sm_100,sm_101,compute_120"
```

the aarch64 cuda 12 wheel only has

```
jax_plugins/xla_cuda12/xla_cuda_plugin.so | SASS:      50 sm_100      50 sm_101      50 sm_120      50 sm_50      50 sm_60      50 sm_70      50 sm_80      50 sm_90 | PTX: 
```

in which none can be run on orin sm87. the first one needs autotuner that need op ends up with no kernel image (#40487). orin cant run sm80 binary, as also indicated by NVIDIA CUDA C Programming Guide 3.1.2 ("Binary compatibility is supported only for the desktop. It is not supported for Tegra."), previous PR #38155 claims "Add Thor SM arch to CUDA build", i tested

```
== arch=compute_80,code=sm_80  ->  launch=no kernel image is available for execution on the device sync=no error h[7]=0
== arch=compute_87,code=sm_87  ->  launch=no error sync=no error h[7]=14
== arch=compute_80,code=compute_80  ->  launch=no error sync=no error h[7]=14
```

this will ends up with another arch, but if you wanted to prefer compute_80 PTX. cuda v13 hasnt been touched.

Fixes #40487
