### PR TITLE
Add FAQ and Sharp Bits links to the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -19,12 +19,19 @@ body:
 
       * If you prefer a non-templated issue report, click [here][Raw report].
 
+      * Before filing, you may want to check the [JAX FAQ][FAQ] and
+      [The Sharp Bits][Sharp Bits] notebook for common questions and gotchas.
+
 
       [Discussions]: https://github.com/jax-ml/jax/discussions
 
       [issue search]: https://github.com/jax-ml/jax/search?q=is%3Aissue&type=issues
 
       [Raw report]: https://github.com/jax-ml/jax/issues/new?template=none
+
+      [FAQ]: https://docs.jax.dev/en/latest/faq.html
+
+      [Sharp Bits]: https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html
 - type: textarea
   attributes:
     label: Description


### PR DESCRIPTION
Fixes #11227.

A recurring pattern in the issue tracker is that a report is answered by pointing at the FAQ or at "JAX - The Sharp Bits" (the `block_until_ready` benchmarking gotcha being the classic one). This links both from the bug report template so they are visible before the issue is filed.

Rendered as the first block of the bug report form:

> * Please first verify that your issue is not already reported using the [Issue search](https://github.com/jax-ml/jax/search?q=is%3Aissue&type=issues).
> * If you are asking a question or seeking support, please consider [starting a discussion](https://github.com/jax-ml/jax/discussions).
> * If you prefer a non-templated issue report, click [here](https://github.com/jax-ml/jax/issues/new?template=none).
> * Before filing, you may want to check the [JAX FAQ](https://docs.jax.dev/en/latest/faq.html) and [The Sharp Bits](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html) notebook for common questions and gotchas.

Notes:
- Uses reference-style links with definitions in the same block, matching the three bullets already there.
- Uses `docs.jax.dev`, which is the domain used everywhere else in the repo.
- Verified the file still parses as valid YAML and that the folded scalar renders as a single bullet.
