### PR TITLE
Reject rather than propagate NaN error ratios in odeint step control

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -136,6 +136,13 @@ def mean_error_ratio(error_estimate, rtol, atol, y0, y1):
 def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
                       dfactor=0.2, order=5.0):
   """Compute optimal Runge-Kutta stepsize."""
+  # A NaN error ratio means the trial step evaluated `func` outside its domain
+  # (e.g. the step was so large that an intermediate stage left the region
+  # where `func` is finite). Treat it like an infinite error so that the step is
+  # shrunk by `dfactor` and retried; otherwise NaN propagates into the step size,
+  # the `dt > 0` loop condition fails, and integration silently stops.
+  mean_error_ratio = jnp.where(jnp.isnan(mean_error_ratio), jnp.inf,
+                               mean_error_ratio)
   dfactor = jnp.where(mean_error_ratio < 1, 1.0, dfactor)
 
   factor = jnp.minimum(ifactor,

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -20,7 +20,7 @@ import numpy as np
 import jax
 from jax._src import test_util as jtu
 import jax.numpy as jnp
-from jax.experimental.ode import odeint
+from jax.experimental.ode import odeint, optimal_step_size
 
 import scipy.integrate as osp_integrate
 
@@ -250,6 +250,28 @@ class ODETest(jtu.JaxTestCase):
 
     self.assertTrue(jnp.abs(ys[1] - 2.) < 1e-4)
     self.assertTrue(jnp.abs(ys[2]) < 1e-4)
+
+  def test_nan_error_ratio_shrinks_step(self):
+    # https://github.com/jax-ml/jax/issues/14612
+    dt = jnp.array(0.1)
+    self.assertAllClose(optimal_step_size(dt, jnp.array(jnp.nan)),
+                        optimal_step_size(dt, jnp.array(jnp.inf)))
+
+  def test_nan_trial_step_is_rejected(self):
+    # https://github.com/jax-ml/jax/issues/14612
+    # Exactly y' = y for y < 20, but NaN beyond it. A trial step large enough to
+    # push an intermediate Runge-Kutta stage past y = 20 yields a NaN error
+    # estimate, which must reject and shrink the step rather than propagate into
+    # the step size, where it would silently end the integration and leave the
+    # remaining outputs to be extrapolated.
+    def rhs(y, t):
+      return y + 0. * jnp.sqrt(20. - y)
+
+    ts = np.linspace(0., np.log(19.9), 5)
+    tol = 1e-4
+    ys = odeint(rhs, jnp.array(1.), jnp.array(ts), rtol=tol, atol=tol)
+    self.assertAllClose(ys, np.exp(ts), check_dtypes=False,
+                        rtol=5 * tol, atol=5 * tol)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #14612.

## bug

A trial Runge-Kutta step can evaluate `func` outside its domain, for example when the step is large enough that an intermediate stage lands where `func` returns NaN. That makes `mean_error_ratio` NaN, and `optimal_step_size` passed it straight through:

```
error_ratio=  inf -> optimal_step_size=0.02   (step shrunk by dfactor, correct)
error_ratio=  nan -> optimal_step_size=nan
```

`jnp.clip(nan, 0, hmax)` is still NaN, `nan > 0` is `False`, so the `while_loop` condition `(t < target_t) & (i < mxstep) & (dt > 0)` fails and integration stops. The loop exits with `t < target_t`, so the remaining outputs are extrapolated from the last accepted state via the interpolant, and nothing in the result is NaN to signal it.

## fix

One elementwise select before the existing arithmetic: a NaN error ratio is mapped to `inf`. The infinite-error path was already correct (`inf ** (-1/order) == 0`, so the factor bottoms out at `dfactor`), so a NaN trial step is now rejected and retried with a smaller step.

## Reproduction and test

The regression test uses `rhs = y + 0. * jnp.sqrt(20. - y)`: `y' = y` while `y < 20`, NaN otherwise, so the reference solution is `exp(t)` with no approximation. Integrating from `y0 = 1` to `t = log(19.9)` with `rtol = atol = 1e-4`:

| | max relative error | ratio to tol |
|---|---|---|
| before | 1.63e-3 | 16x |
| after | 3.7e-5 | 0.4x |

The same 16x-vs-0.4x split holds with x64 disabled, so the test discriminates in both modes; I ran it against the old `optimal_step_size` in both modes and it fails as expected. A second small test pins `optimal_step_size(dt, nan) == optimal_step_size(dt, inf)`.

`tests/ode_test.py` passes in full (16 tests) with `JAX_ENABLE_X64` on and off.

an `rhs` that is NaN everywhere is unaffected by this change.
