### PR TITLE
Handle cluster detection for Open MPI 5

### DIFF
--- a/jax/_src/clusters/ompi_cluster.py
+++ b/jax/_src/clusters/ompi_cluster.py
@@ -18,8 +18,11 @@ import os
 import re
 from jax._src import clusters
 
-#  OMPI_MCA_orte_hnp_uri exists only when processes are launched via mpirun or mpiexec
+# OMPI_MCA_orte_hnp_uri exists only when processes are launched via mpirun or mpiexec
+# in ORTE-based Open MPI (<5). PRRTE-based Open MPI 5 programs are routed to
+# Mpi4pyCluster detection
 _ORTE_URI = 'OMPI_MCA_orte_hnp_uri'
+_OMPI_VERSION = 'OMPI_VERSION'
 _PROCESS_COUNT = 'OMPI_COMM_WORLD_SIZE'
 _PROCESS_ID = 'OMPI_COMM_WORLD_RANK'
 _LOCAL_PROCESS_ID = 'OMPI_COMM_WORLD_LOCAL_RANK'
@@ -29,11 +32,47 @@ class OmpiCluster(clusters.ClusterEnv):
   name: str = "ompi"
 
   @classmethod
+  def _is_ompi_5(cls) -> bool:
+    # Use OMPI_VERSION when available; otherwise distinguish ORTE from PRRTE
+    # by the presence of the legacy ORTE URI.
+    if not all(
+        variable in os.environ
+        for variable in (_PROCESS_COUNT, _PROCESS_ID, _LOCAL_PROCESS_ID)
+    ):
+      return False
+
+    try:
+      major_version = int(
+          os.environ.get(_OMPI_VERSION, '').split('.', maxsplit=1)[0]
+      )
+    except ValueError:
+      # OMPI_VERSION is not guaranteed. The legacy launcher always provides
+      # its ORTE URI, whereas the PRRTE launcher does not.
+      return _ORTE_URI not in os.environ
+    return major_version >= 5
+
+  @classmethod
+  def _mpi4py_cluster(cls) -> type[clusters.ClusterEnv]:
+    from jax._src.clusters.mpi4py_cluster import Mpi4pyCluster
+    if not Mpi4pyCluster.is_env_present():
+      raise RuntimeError(
+          "Open MPI 5 or newer requires mpi4py for distributed "
+          "initialization."
+      )
+    return Mpi4pyCluster
+
+  @classmethod
   def is_env_present(cls) -> bool:
-    return _ORTE_URI in os.environ
+    return _ORTE_URI in os.environ or cls._is_ompi_5()
 
   @classmethod
   def get_coordinator_address(cls, timeout_secs: int | None, override_coordinator_port: str | None) -> str:
+    if cls._is_ompi_5():
+      return cls._mpi4py_cluster().get_coordinator_address(
+          timeout_secs=timeout_secs,
+          override_coordinator_port=override_coordinator_port,
+      )
+
     # Examples of orte_uri:
     # 1531576320.0;tcp://10.96.0.1,10.148.0.1,10.108.0.1:34911
     # 1314521088.0;tcp6://[fe80::b9b:ac5d:9cf0:b858,2620:10d:c083:150e::3000:2]:43370
@@ -55,12 +94,18 @@ class OmpiCluster(clusters.ClusterEnv):
 
   @classmethod
   def get_process_count(cls) -> int:
+    if cls._is_ompi_5():
+      return cls._mpi4py_cluster().get_process_count()
     return int(os.environ[_PROCESS_COUNT])
 
   @classmethod
   def get_process_id(cls) -> int:
+    if cls._is_ompi_5():
+      return cls._mpi4py_cluster().get_process_id()
     return int(os.environ[_PROCESS_ID])
 
   @classmethod
   def get_local_process_id(cls) -> int | None:
+    if cls._is_ompi_5():
+      return cls._mpi4py_cluster().get_local_process_id()
     return int(os.environ[_LOCAL_PROCESS_ID])

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -299,7 +299,8 @@ def initialize(coordinator_address: str | None = None,
   distributed arguments. You may pass any of the automatic ``spec_detect_methods`` to this
   argument though it is not necessary in the TPU, Slurm, or Open MPI cases.  For other MPI
   installations, if you have a functional ``mpi4py`` installed, you may pass
-  ``cluster_detection_method="mpi4py"`` to bootstrap the required arguments.
+  ``cluster_detection_method="mpi4py"`` to bootstrap the required arguments. Open MPI 5
+  and newer also require a functional ``mpi4py`` installation for automatic detection.
 
   Otherwise, you must provide the ``coordinator_address``,
   ``num_processes``, ``process_id``, and ``local_device_ids`` arguments

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -14,6 +14,7 @@
 
 import functools
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -38,6 +39,17 @@ except ImportError:
   portpicker = None
 
 jax.config.parse_flags_with_absl()
+
+
+def _open_mpi_major_version() -> int | None:
+  result = subprocess.run(
+      ["mpirun", "--version"],
+      capture_output=True,
+      check=False,
+      text=True,
+  )
+  match = re.search(r"Open MPI\)?\s+v?(\d+)", result.stdout + result.stderr)
+  return int(match.group(1)) if match else None
 
 
 @unittest.skipIf(not portpicker, "Test requires portpicker")
@@ -143,6 +155,11 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
       raise unittest.SkipTest('Tests only for GPU.')
     if shutil.which('mpirun') is None:
       raise unittest.SkipTest('Tests only for MPI (mpirun not found).')
+    if (
+        importlib.util.find_spec("mpi4py") is None
+        and (_open_mpi_major_version() or 0) >= 5
+    ):
+      raise unittest.SkipTest('Open MPI 5 or newer requires mpi4py.')
 
     num_gpus = 4
     num_gpus_per_task = 1
@@ -164,14 +181,18 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
     # In case the job was launched via Slurm,
     # prevent OpenMPI from detecting Slurm environment
     env.pop('SLURM_JOBID', None)
+    env.pop('SLURM_JOB_ID', None)
     proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, universal_newlines=True)
     proc = self.enter_context(proc)
 
     try:
-      out, _ = proc.communicate()
-      self.assertEqual(proc.returncode, 0)
-      self.assertEqual(out, f'{num_gpus_per_task},{num_gpus}')
+      out, err = proc.communicate()
+      self.assertEqual(
+          proc.returncode, 0, msg=f"Process failed:\n\n{out}\n\n{err}"
+      )
+      # MPI transports may emit diagnostics to stdout before the result.
+      self.assertRegex(out, rf'{num_gpus_per_task},{num_gpus}$')
     finally:
       proc.kill()
 
@@ -195,7 +216,7 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
         sys.executable,
         '-c',
         ('import jax, os; '
-        'jax.distributed.initialize(spec_detection_method="mpi4py"); '
+        'jax.distributed.initialize(cluster_detection_method="mpi4py"); '
         'print(f\'{jax.local_device_count()},{jax.device_count()}\' if jax.process_index() == 0 else \'\', end="")'
         )
     ]
@@ -208,9 +229,12 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
     proc = self.enter_context(proc)
 
     try:
-      out, _ = proc.communicate()
-      self.assertEqual(proc.returncode, 0)
-      self.assertEqual(out, f'{num_gpus_per_task},{num_gpus}')
+      out, err = proc.communicate()
+      self.assertEqual(
+          proc.returncode, 0, msg=f"Process failed:\n\n{out}\n\n{err}"
+      )
+      # MPI transports may emit diagnostics to stdout before the result.
+      self.assertRegex(out, rf'{num_gpus_per_task},{num_gpus}$')
     finally:
       proc.kill()
 


### PR DESCRIPTION
Update Open MPI cluster detection to handle Open MPI v5.0 by routing it through JAX's `Mpi4pyCluster`.

The current `OmpiCluster` implementation is based on using ORTE rank variables (e.g `OMPI_MCA_orte_hnp_uri` for setting the coordinator address) which is not forward compatible with PRRTE-based OMPI 5 launched workloads, e.g we observe `multiprocess_gpu_test.py::MultiProcessGpuTest::test_gpu_ompi_distributed_initialize` failing when installed `mpirun` version is `5.0.10rc2`.

This addresses #14576 by preserving the existing ORTE path for pre-v5 Open MPI versions while routing Open MPI 5+ cluster discovery through `Mpi4pyCluster`.