### PR TITLE
checkify: fix dtype mismatch when jax.enable_x64() scope is nested inside checkified function

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -325,7 +325,10 @@ def assert_func(ctx: CheckifyContext, error: Error, pred: Bool,
 def update_error(error, pred, code, metadata, payload, effect_type):
   err_of_type = error._pred.get(effect_type, False)
   out_err = err_of_type | pred
-  out_code = lax.select(err_of_type, error._code.get(effect_type, _INACTIVE_CODE), code)
+  cur_code = error._code.get(effect_type)
+  if cur_code is None:
+    cur_code = lax.full_like(code, _INACTIVE_CODE)
+  out_code = lax.select(err_of_type, cur_code, code)
   cur_payload = error._payload.get(effect_type, None)
   if cur_payload is not None:
     out_payload = tree_map(functools.partial(lax.select, err_of_type), cur_payload, payload)

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -1544,6 +1544,29 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(JaxRuntimeError, "Inner check failed!"):
       err.throw()
 
+  def test_check_inside_local_enable_x64_scope(self):
+    prev = config.explicit_x64_dtypes.value
+    config.update('jax_explicit_x64_dtypes', 'allow')
+    try:
+      def f(x):
+        with jax.enable_x64():
+          checkify.check(x > 0, "positive")
+          return x
+
+      checked_f = jax.jit(checkify.checkify(f))
+      err, out = checked_f(jnp.ones((), dtype=jnp.float64))
+      self.assertIs(err.get(), None)
+      self.assertEqual(out, 1.0)
+
+      err, out = checked_f(jnp.array(-1.0, dtype=jnp.float64))
+      self.assertIsNotNone(err.get())
+      self.assertStartsWith(err.get(), "positive")
+
+      err, out = checkify.checkify(jax.jit(f))(jnp.ones((), dtype=jnp.float64))
+      self.assertIs(err.get(), None)
+    finally:
+      config.update('jax_explicit_x64_dtypes', prev)
+
   def test_nested_checkify_namespace_collision(self):
     def g(y):
       checkify.check(y > 0, "inner check failed")


### PR DESCRIPTION
Fixes #40482

## Root cause

`update_error` in `jax/_src/checkify.py` merges error codes with
`lax.select`. When there's no existing code for a given effect type yet,
it fell back to the bare Python int `_INACTIVE_CODE` (-2):

```python
out_code = lax.select(err_of_type, error._code.get(effect_type, _INACTIVE_CODE), code)
```

Because `_INACTIVE_CODE` is a plain Python literal, its dtype is resolved
lazily, using whatever the *ambient* x64 config happens to be at the exact
moment `lax.select` runs. `checkify` traces a function in one pass (where a
local `jax.enable_x64()` scope may be active) and then discharges/rewrites
`check` primitives in a separate later pass over the already-built jaxpr
(where that scope has already exited). This means the real error `code`
and the `_INACTIVE_CODE` fallback can end up resolved in different passes,
under different ambient x64 settings — producing a dtype mismatch
(`int64` vs `int32`) that `lax.select` rejects (unlike `jnp.where`, which
promotes).

## Fix

Seed the fallback using `lax.full_like(code, _INACTIVE_CODE)` instead of a
bare Python int, so it always matches `code`'s dtype (and shape) directly,
regardless of ambient config at the point `lax.select` runs.

## Testing

- Verified the exact repro from #40482 now passes for both
  `jit(checkify(f))` and `checkify(jit(f))` orderings.
- Added a regression test
  (`test_check_inside_local_enable_x64_scope` in `tests/checkify_test.py`).
  Confirmed it fails with the original `TypeError` when the fix is
  reverted, and passes with the fix applied.
- Ran the full `checkify_test.py` suite: 114 passed (113 existing + 1 new),
  no regressions.