### PR TITLE
Make remat policy sentinels' truthiness match their meaning

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -243,7 +243,12 @@ def _debug_partial_eval_custom(saveable, unks_in, inst_in, eqn, primitive):
     # The usual case (if we have any unknowns, we need to stage it out)
     res = [v for v, inst in zip(eqn.invars, inst_in) if not inst]
     return None, eqn, [], [], res
-  if saveable(primitive, *[v.aval for v in eqn.invars], **eqn.params):
+  # A policy may return a RematCases sentinel rather than a bool, so normalise
+  # before deciding. Offloadable means "keep it", which for a callback with
+  # nothing to offload is the same decision as Saveable.
+  policy_result = pe.ensure_enum(
+      saveable(primitive, *[v.aval for v in eqn.invars], **eqn.params))
+  if policy_result is not pe.Recompute:
     # The policy is telling us we can save the debug callback.
     if all(inst_in):
       # If all of the inputs are instantiated, we also stage out the

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -960,15 +960,31 @@ def _partial_eval_jaxpr_custom_cached(
 
 MemoryKind = str
 
-class RecomputeType: pass
+# What a remat policy returns instead of a bool. Truthiness is spelled out
+# because a policy result can reach raw boolean context: RematCases_ admits both
+# bools and these sentinels, and not every consumer routes through ensure_enum.
+# Left implicit, all three are truthy, so Recompute reads as "save" -- the
+# opposite of what it means.
+class RecomputeType:
+  def __bool__(self) -> bool:
+    return False
 Recompute = RecomputeType()
 
-class SaveableType: pass
+class SaveableType:
+  def __bool__(self) -> bool:
+    return True
 Saveable = SaveableType()
 
 class Offloadable(NamedTuple):
   src: MemoryKind
   dst: MemoryKind
+
+  def __bool__(self) -> bool:
+    # Offloading keeps the value rather than recomputing it, so this is truthy
+    # for the same reason Saveable is. Written out rather than inherited from
+    # tuple, whose truthiness is its length and would flip if a field were
+    # added or removed.
+    return True
 
 RematCases = RecomputeType | SaveableType | Offloadable
 RematCases_ = RematCases | bool

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7400,6 +7400,26 @@ class RematTest(jtu.JaxTestCase):
           names_which_can_be_saved=['y'], names_which_can_be_offloaded=['y'],
           offload_src='device', offload_dst='pinned_host')
 
+  def test_remat_policy_sentinel_truthiness(self):
+    # RematCases_ admits both bools and the RematCases sentinels, and not every
+    # consumer of a policy result routes it through ensure_enum. So each
+    # sentinel's truthiness has to match its meaning.
+    offloadable = pe.Offloadable(src='device', dst='pinned_host')
+    self.assertFalse(pe.Recompute)
+    self.assertTrue(pe.Saveable)
+    self.assertTrue(offloadable)  # offloading keeps the value, it does not recompute it
+
+    # __bool__ must leave ensure_enum alone: it dispatches on
+    # isinstance(case, bool), which is False for all three either way.
+    self.assertIs(pe.ensure_enum(False), pe.Recompute)
+    self.assertIs(pe.ensure_enum(True), pe.Saveable)
+    self.assertIs(pe.ensure_enum(pe.Recompute), pe.Recompute)
+    self.assertIs(pe.ensure_enum(pe.Saveable), pe.Saveable)
+    self.assertIs(pe.ensure_enum(offloadable), offloadable)
+
+    # Offloadable is still an ordinary NamedTuple.
+    self.assertEqual(tuple(offloadable), ('device', 'pinned_host'))
+
   def test_remat_offload_names_of_scan_jaxpr(self):
     # Like test_remat_offload_names_jaxpr, but with the named values inside a
     # scan body: the per-iteration offloaded copies are saved as stacked

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -471,6 +471,40 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
     # We expect the print to happen twice since it is rematerialized.
     self.assertEqual(output(), "y: 3.0, z: 6.0\n" * 2)
 
+  def test_remat_of_debug_print_with_sentinel_policy(self):
+    # Same situation as test_remat_of_debug_print, but with a policy that
+    # returns RematCases sentinels instead of bools. Recompute has to mean what
+    # False means: do not save the callback, so it is printed on the recompute
+    # too.
+    def f_(x):
+      a = ad_checkpoint.checkpoint_name(x + 1., "a")
+      b = ad_checkpoint.checkpoint_name(x * 3., "b")
+      debug_print('a: {}, b: {}', a, b)
+      return jnp.sin(a) * jnp.cos(b)
+
+    # Both of these say the same thing about the debug callback -- it is not in
+    # the allow-list, so do not save it -- but one says it with False and the
+    # other with ad_checkpoint.Recompute. Saving "a" and not "b" is what makes
+    # the callback's inputs only partly instantiated, which is the case where
+    # the two branches of the rule differ.
+    policies = [
+        ad_checkpoint.save_only_these_names("a"),
+        ad_checkpoint.save_and_offload_only_these_names(
+            names_which_can_be_saved=["a"], names_which_can_be_offloaded=[],
+            offload_src='device', offload_dst='pinned_host'),
+    ]
+
+    outputs = []
+    for policy in policies:
+      with jtu.capture_stdout() as output:
+        jax.grad(jax.checkpoint(f_, policy=policy))(2.)
+        jax.effects_barrier()
+      outputs.append(output())
+
+    # Printed twice under either spelling, since the callback is rematerialized.
+    self.assertEqual(outputs[0], "a: 3.0, b: 6.0\n" * 2)
+    self.assertEqual(outputs[1], outputs[0])
+
   def test_debug_print_in_staged_out_custom_jvp(self):
     @jax.jit
     def f(x):


### PR DESCRIPTION
A remat policy may return either a bool or one of the RematCases sentinels --

    RematCases  = RecomputeType | SaveableType | Offloadable
    RematCases_ = RematCases | bool

-- and consumers are supposed to normalise through ensure_enum. All three
sentinels are currently truthy: Recompute and Saveable are bare class instances
with no __bool__ and no __len__, and Offloadable is truthy by tuple length. So
in raw boolean context Recompute reads as "save", the opposite of what it means.

Two places consume a policy result outside ensure_enum. One of them,
ad_checkpoint.save_from_both_policies, already noticed the hazard and rejects
non-bools with an explicit isinstance check and a clear error. The other,
_debug_partial_eval_custom in debugging.py, does not:

    if saveable(primitive, *[v.aval for v in eqn.invars], **eqn.params):

The two branches are not equivalent. When the callback's inputs are not all
instantiated, the saveable branch returns (eqn, None, ...) and the recompute
branch returns (eqn, eqn, ...) -- so this changes staging, it does not merely
ignore a setting.

Reachable from the public API. Both policies below say the same thing about the
debug callback -- it is not in the allow-list, do not save it -- but one says it
with False and the other with Recompute:

    def f(x):
      a = checkpoint_name(x + 1., "a")
      b = checkpoint_name(x * 3., "b")
      jax.debug.print('a={} b={}', a, b)
      return jnp.sin(a) * jnp.cos(b)

    jax.grad(jax.checkpoint(f, policy=P))(2.)

    P = jax.checkpoint_policies.save_only_these_names("a")
        -> returns bools     -> the print runs 2 times
    P = jax.checkpoint_policies.save_and_offload_only_these_names(
            names_which_can_be_saved=["a"], names_which_can_be_offloaded=[],
            offload_src='device', offload_dst='pinned_host')
        -> returns sentinels -> the print runs 1 time

Saving "a" but not "b" is what matters: it leaves the callback's inputs only
partly instantiated, which is the case where the two branches differ. A uniform
policy (nothing_saveable, or an empty allow-list) hits all(inst_in) and both
branches agree, which is why this has gone unnoticed. 3 of the 15 names in
jax.checkpoint_policies return sentinels, backed by two policy classes:
SaveAndOffloadOnlyTheseNames and OffloadDotWithNoBatchDims.

This fixes the class of bug at the source by giving the sentinels an explicit
__bool__, so any present or future boolean-context consumer gets the right
answer, and also normalises the debugging.py call site through ensure_enum.
Either half alone fixes the symptom; all four combinations were verified:

    __bool__   ensure_enum   prints
    no         no            1   <- current main
    yes        no            2
    no         yes           2
    yes        yes           2

Offloadable.__bool__ is written out rather than inherited from tuple, whose
truthiness is its length and would flip if a field were added or removed.

ensure_enum is unperturbed: it dispatches on isinstance(case, bool), which is
False for all three sentinels regardless of __bool__. A test pins that, along
with Offloadable still behaving as a NamedTuple.

Nothing else in the tree relies on the old truthiness: an AST scan of jax/ and
tests/ for these three names in if/while/not/and/or/assert/comprehension
position finds zero occurrences.

    tests/debugging_primitives_test.py
      before: 1 failed, 67 passed, 1 skipped
      after:  68 passed, 1 skipped
    tests/api_test.py -k "remat or policy or offload or checkpoint"
      before: 2 failed, 259 passed, 6 skipped
      after:  261 passed, 6 skipped

The failures before are exactly the tests added here; nothing else changes.
(test_remat_policy_sentinel_truthiness counts twice because Remat3Test inherits
from RematTest.)
