### PR TITLE
fix(pjit): improve pytree prefix error messages for None and PytreeLeaf

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -405,7 +405,7 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
                    f"means that {name} might need to be wrapped in "
                    f"a singleton tuple.")
     dummy_tree = tree_unflatten(treedef, [PytreeLeaf()] * treedef.num_leaves)
-    errors = prefix_errors(axis_tree, dummy_tree)
+    errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
     if errors:
       details = "\n  ".join(e(name).args[0] for e in errors)
       prefix_err_msg = (
@@ -469,7 +469,7 @@ def flatten_axis_resources(what, tree, shardings, tupled_args):
   # Because we only have the `tree` treedef and not the full pytree here,
   # we construct a dummy tree to compare against. Revise this in callers?
   dummy_tree = tree_unflatten(tree, [PytreeLeaf()] * tree.num_leaves)
-  errors = prefix_errors(axis_tree, dummy_tree)
+  errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
   if errors:
     details = "\n".join(e(what).args[0] for e in errors)
     raise ValueError(

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -773,9 +773,16 @@ def _equality_errors(path, t1, t2, is_leaf):
   if (treedef_is_strict_leaf(tree_structure(t1, is_leaf=is_leaf)) and
       treedef_is_strict_leaf(tree_structure(t2, is_leaf=is_leaf))): return
 
+  def _type_name(t: Any) -> str:
+    if t is None:
+      return "None"
+    if type(t).__name__ in ("PytreeLeaf", "Leaf"):
+      return "pytree leaf"
+    return str(type(t))
+
   # The trees may disagree because they are different types:
   if type(t1) != type(t2):
-    yield path, str(type(t1)), str(type(t2)), 'their Python types differ'
+    yield path, _type_name(t1), _type_name(t2), 'their Python types differ'
     return  # no more errors to find
 
   # Or they may disagree because their roots have different numbers or keys of
@@ -1286,13 +1293,22 @@ def _prefix_error(
 
   # The subtrees may disagree because their roots are of different types:
   if type(prefix_tree) != type(full_tree):
+    def _desc(t: Any, is_prefix: bool) -> str:
+      if t is None:
+        return "None"
+      if type(t).__name__ in ("PytreeLeaf", "Leaf"):
+        return "a leaf"
+      prefix = "a subtree of type\n    " if is_prefix else "a subtree of different type\n    "
+      return f"{prefix}{type(t)}"
+
+    prefix_desc = _desc(prefix_tree, is_prefix=True)
+    full_desc = _desc(full_tree, is_prefix=False)
+
     yield lambda name: ValueError(
       "pytree structure error: different types at key path\n"
       f"    {name}{keystr(key_path)}\n"
-      f"At that key path, the prefix pytree {name} has a subtree of type\n"
-      f"    {type(prefix_tree)}\n"
-      f"but at the same key path the full pytree has a subtree of different type\n"
-      f"    {type(full_tree)}.")
+      f"At that key path, the prefix pytree {name} has {prefix_desc}\n"
+      f"but at the same key path the full pytree has {full_desc}.")
     return  # don't look for more errors in this subtree
 
   # Or they may disagree if their roots have different numbers or keys of
@@ -1368,7 +1384,7 @@ def _prefix_error(
     ("equal pytree nodes gave differing prefix_tree_keys: "
      f"{prefix_tree_keys} and {full_tree_keys}")
   for k, t1, t2 in zip(prefix_tree_keys, prefix_tree_children, full_tree_children):
-    yield from _prefix_error((*key_path, k), t1, t2)
+    yield from _prefix_error((*key_path, k), t1, t2, is_leaf)
 
 def _ensure_inbounds(allow_invalid: bool, num_args: int, argnums: Sequence[int]
                      ) -> tuple[int, ...]:

--- a/tests/api_util_test.py
+++ b/tests/api_util_test.py
@@ -127,6 +127,18 @@ class ApiUtilTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, r"Mismatch details \(2 found\)"):
       api_util.flatten_axis_resources("test_spec", tree, shardings, False)
 
+  def test_flatten_axis_resources_error_no_pytreeleaf_and_handles_none(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/13074
+    tree = jax.tree.structure({"a": 1, "b": 2})
+    shardings = {"a": None, "b": (None, None)}
+    with self.assertRaises(ValueError) as cm:
+      api_util.flatten_axis_resources("in_axis_resources", tree, shardings, False)
+    msg = str(cm.exception)
+    self.assertNotIn("PytreeLeaf", msg)
+    self.assertNotIn("NoneType", msg)
+    self.assertIn("has a leaf", msg)
+    self.assertIn("Mismatch details (1 found)", msg)
+
   def test_fun_sourceinfo(self):
     fsi = api_util.fun_sourceinfo
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1579,6 +1579,21 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
+  def test_prefix_errors_leaf_and_none(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/13074:
+    # equality_errors_pytreedef should say "None" not "<class 'NoneType'>"
+    # and "pytree leaf" not the internal LeafMeta class name.
+    from jax._src.tree_util import equality_errors_pytreedef
+    t1 = jax.tree.structure({"a": None, "b": (1, 2)})
+    t2 = jax.tree.structure({"a": (1, 2), "b": 3})
+    errs = list(equality_errors_pytreedef(t1, t2))
+    # 'a': None in t1 vs (1,2) in t2 — should say "None" not "NoneType"
+    self.assertEqual(errs[0][1], "None")
+    self.assertNotIn("NoneType", errs[0][1])
+    # 'b': (1,2) in t1 vs leaf(3) in t2 — should say "pytree leaf", not LeafMeta
+    self.assertEqual(errs[1][2], "pytree leaf")
+    self.assertNotIn("LeafMeta", errs[1][2])
+
 
 class TreeAliasTest(jtu.JaxTestCase):
   """Simple smoke-tests for tree_util aliases under jax.tree"""


### PR DESCRIPTION
Fixes #13074

Two improvements to the error messages raised when `pjit`'s `in_axis_resources`/`in_shardings` is not a pytree prefix of the arguments:

1. **Don't expose `PytreeLeaf` in error messages**: `flatten_axes` and `flatten_axis_resources` fill dummy trees with internal `PytreeLeaf` sentinel objects. These were leaking into user-facing error messages as `<class'jax._src.api_util.PytreeLeaf'>`. Now they show as `"a leaf"` / `"pytree leaf"`.

2. **Handle `None` specially**: `None` is the standard "replicated / no sharding" sentinel. Previously it could trigger false-positive mismatch errors and appear as `<class 'NoneType'>` in messages. Now `None` is treated as a valid leaf in `prefix_errors` calls, and renders as `"None"` in `equality_errors_pytreedef` output.

Regression tests added in `tests/api_util_test.py` and `tests/tree_util_test.py`.