### PR TITLE
docs(lax): improve conv_transpose TensorFlow compatibility note (#14337)

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -307,11 +307,11 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
   indirectly calculating the gradient (transpose) of a forward convolution.
 
   Notes:
-    TensorFlow/Keras Compatibility: By default, JAX does NOT reverse the
-    kernel's spatial dimensions. This differs from TensorFlow's "Conv2DTranspose"
+    **TensorFlow/Keras Compatibility**: By default, JAX does NOT reverse the
+    kernel's spatial dimensions. This differs from TensorFlow's `tf.keras.layers.Conv2DTranspose`
     and similar frameworks, which flip spatial axes and swap input/output channels.
 
-    To match TensorFlow/Keras behavior, set "transpose_kernel=True" .
+    To match TensorFlow/Keras behavior, set `transpose_kernel=True` .
 
   Args:
     lhs: a rank `n+2` dimensional input array.


### PR DESCRIPTION
Fixes #14337

### Description
Improves formatting and clarifies the note in `jax.lax.conv_transpose` regarding compatibility with TensorFlow/Keras (`transpose_kernel=True`).