### PR TITLE
Numeric underflow bugfix for Hessian of SVD

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -2362,10 +2362,9 @@ def _svd_jvp_rule(
   if not compute_uv:
     return (s,), (ds,)
 
-  s_diffs = (s_dim + _T(s_dim)) * (s_dim - _T(s_dim))
+  # s_diffs = (s_dim + _T(s_dim)) * (s_dim - _T(s_dim))
   s_diffs_zeros = lax._eye(s.dtype, (s.shape[-1], s.shape[-1]))  # jnp.ones((), dtype=A.dtype) * (s_diffs == 0.)  # is 1. where s_diffs is 0. and is 0. everywhere else
-  s_diffs_zeros = lax.expand_dims(s_diffs_zeros, range(s_diffs.ndim - 2))
-  F = 1 / (s_diffs + s_diffs_zeros) - s_diffs_zeros
+  s_diffs_zeros = lax.expand_dims(s_diffs_zeros, range(s_dim.ndim - 2))
   dSS = s_dim.astype(A.dtype) * dS  # dS.dot(jnp.diag(s))
   SdS = _T(s_dim.astype(A.dtype)) * dS  # jnp.diag(s).dot(dS)
 
@@ -2373,8 +2372,11 @@ def _svd_jvp_rule(
   s_inv = 1 / (s + s_zeros) - s_zeros
   s_inv_mat = _construct_diagonal(s_inv)
   dUdV_diag = .5 * (dS - _H(dS)) * s_inv_mat.astype(A.dtype)
-  dU = U @ (F.astype(A.dtype) * (dSS + _H(dSS)) + dUdV_diag)
-  dV = V @ (F.astype(A.dtype) * (SdS + _H(SdS)))
+  mask_div1 = (1 - s_diffs_zeros) / (s_dim + _T(s_dim) + s_diffs_zeros)
+  mask_div1 = mask_div1.astype(A.dtype)
+  div2 = (s_dim - _T(s_dim) + s_diffs_zeros).astype(A.dtype)
+  dU = U @ (((dSS + _H(dSS)) * mask_div1) / div2 + dUdV_diag)
+  dV = V @ (((SdS + _H(SdS)) * mask_div1) / div2)
 
   m, n = A.shape[-2:]
   if m > n:

--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -272,6 +272,77 @@ class SvdTest(jtu.JaxTestCase):
                         atol=1E-6)
 
   @jtu.sample_product(
+   a11=[0,1,2,3,4],
+   a12=[0,1,2,3,4],
+   a13=[0,1,2,3,4],
+   a21=[0,1,2,3,4],
+   a22=[0,1,2,3,4],
+   a23=[0,1,2,3,4],
+   a31=[0,1,2,3,4],
+   a32=[0,1,2,3,4],
+   a33=[0,1,2,3,4],
+   fi=[0,1,2],
+   fj=[0,1,2],
+   dtype=jtu.dtypes.floating,
+  )
+  def testHessianSvdForUnderflow(self, a11,a12,a13,a21,a22,a23,a31,a32,a33,
+                                 fi,fj,dtype):
+    """Tests if the Hessian of an SVD underflows numerically. Intended to guard
+    against #40185. """
+    a = jnp.array([
+      [a11,a12,a13],
+      [a21,a22,a23],
+      [a31,a32,a33],
+    ], dtype=dtype)
+    a = a.at[fi, fj].set(-a[fi,fj])
+    # Underflow occurs due to error, and this is nigh inevitable. The x10 is
+    # meant to check only for errors occurring very far away from the float
+    # limits, as these are a much bigger problem.
+    a = jnp.finfo(dtype).tiny * a * 10
+
+    def total_sigma(M):
+      return jnp.linalg.svd(M, compute_uv=False).sum()
+
+    res = jax.hessian(total_sigma)(a)
+    self.assertFalse(jnp.any(jnp.isnan(res)))
+
+  @jtu.sample_product(
+   a11=[0,1,2,3,4],
+   a12=[0,1,2,3,4],
+   a13=[0,1,2,3,4],
+   a21=[0,1,2,3,4],
+   a22=[0,1,2,3,4],
+   a23=[0,1,2,3,4],
+   a31=[0,1,2,3,4],
+   a32=[0,1,2,3,4],
+   a33=[0,1,2,3,4],
+   fi=[0,1,2],
+   fj=[0,1,2],
+   dtype=jtu.dtypes.floating,
+  )
+  def testHessianSvdForOverflow(self, a11,a12,a13,a21,a22,a23,a31,a32,a33,
+                                 fi,fj,dtype):
+    """Tests if the Hessian of an SVD overflows numerically. Intended to guard
+    against #40185. """
+    a = jnp.array([
+      [a11,a12,a13],
+      [a21,a22,a23],
+      [a31,a32,a33],
+    ], dtype=dtype)
+    a = a.at[fi, fj].set(-a[fi,fj])
+    # The comment in testHessianSvdForUnderflow applies here too: slight errors
+    # typically lead to overflow near the bounds anyways, so the /10 ensures
+    # we're not being unreasonably strict, i.e. we get sufficiently near the
+    # expressable bounds.
+    a = jnp.finfo(dtype).max/10 * a
+
+    def total_sigma(M):
+      return jnp.linalg.svd(M, compute_uv=False).sum()
+
+    res = jax.hessian(total_sigma)(a)
+    self.assertFalse(jnp.any(jnp.isnan(res)))
+
+  @jtu.sample_product(
       start=[0, 1, 64, 126, 127],
       end=[1, 2, 65, 127, 128],
   )


### PR DESCRIPTION
Fixes #40185.

The bug here was numeric underflow: when the scale of the input matrix is outside `(sqrt(min),sqrt(max))`, `nan`s would show up in the Hessian. This fix allows input matrix's scale to approach the `min` much more closely.

Summary of changes:
- Changed the order of calculations for svd's jvp. This avoids an intermediate calculation which was causing the underflow.
- Added two tests to confirm this works. These don't go all the way to `max` and `min` (I suspect the error bound causes under/overflow anyways), but they go to within an order of magnitude from them. (Not sure if this can be strengthened.)

[This is my first PR, let me know if I made any rookie mistakes.]