### PR TITLE
[OneAPI GPU] Add OneAPI Linalg custom kernels. Cholesky Update, LU Pivots to permutations and Tridiagonal Solve

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -993,6 +993,9 @@ mlir.register_lowering(
     cholesky_update_p, partial(_cholesky_update_gpu_lowering_rule, "cu"),
     platform="cuda")
 mlir.register_lowering(
+    cholesky_update_p, partial(_cholesky_update_gpu_lowering_rule, "oneapi"),
+    platform="oneapi")
+mlir.register_lowering(
     cholesky_update_p,
     mlir.lower_fun(_cholesky_update_jax_fn, multiple_results=False))
 
@@ -1955,7 +1958,7 @@ mlir.register_lowering(
     mlir.lower_fun(_generic_lu_pivots_to_permutation, multiple_results=False))
 register_cpu_gpu_lowering(
     lu_pivots_to_permutation_p, _lu_pivots_to_permutation_gpu_lowering,
-    ("cuda", "rocm"))
+    ("cuda", "rocm", "oneapi"))
 
 
 # QR decomposition
@@ -2924,7 +2927,8 @@ def _tridiagonal_solve_gpu_lowering(ctx, dl, d, du, b, *, target_name_prefix,
     return rule(ctx, dl, d, du, b)
 
   # The cusolver implementation requires m >= 3.
-  if m <= 2:
+  # OneAPI uses the JAX decomposition for non-perturbed solves.
+  if m <= 2 or target_name_prefix == "oneapi":
     return mlir.lower_fun(_tridiagonal_solve_jax, multiple_results=False)(
         ctx, dl, d, du, b, perturb_singular=perturb_singular)
   target_name = f"{target_name_prefix}sparse_gtsv2_ffi"
@@ -3056,6 +3060,10 @@ mlir.register_lowering(
     tridiagonal_solve_p,
     partial(_tridiagonal_solve_gpu_lowering, target_name_prefix='hip'),
     platform='rocm')
+mlir.register_lowering(
+    tridiagonal_solve_p,
+  partial(_tridiagonal_solve_gpu_lowering, target_name_prefix='oneapi'),
+    platform='oneapi')
 mlir.register_lowering(tridiagonal_solve_p, mlir.lower_fun(
     _tridiagonal_solve_jax, multiple_results=False))
 

--- a/jaxlib/gpu/BUILD
+++ b/jaxlib/gpu/BUILD
@@ -47,6 +47,7 @@ exports_files(srcs = [
     "linalg.cc",
     "linalg_kernels.cc",
     "linalg_kernels.cu.cc",
+    "linalg_kernels_oneapi.cc",
     "linalg_kernels.h",
     "make_batch_pointers.cu.cc",
     "make_batch_pointers.h",

--- a/jaxlib/gpu/linalg_kernels_oneapi.cc
+++ b/jaxlib/gpu/linalg_kernels_oneapi.cc
@@ -1,0 +1,263 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "jaxlib/gpu/linalg_kernels.h"
+
+#include <cstdint>
+
+#include <algorithm>
+#include <complex>
+
+#include "absl/status/status.h"
+#include "jaxlib/gpu/gpu_kernel_helpers.h"
+#include "jaxlib/gpu/vendor.h"
+#include "jaxlib/tridiagonal_solve_perturbed.h"
+
+namespace jax {
+namespace JAX_GPU_NAMESPACE {
+
+namespace {
+
+template <typename T>
+void drotg(T* da, T* db, T* c, T* s) {
+  if (*db == 0) {
+    *c = 1.;
+    *s = 0.;
+    return;
+  }
+  T denominator = std::max(std::abs(*da), std::abs(*db));
+  T a = *da / denominator;
+  T b = *db / denominator;
+  T rh = T(1) / std::hypot(a, b);
+  *c = a * rh;
+  *s = -(b * rh);
+}
+
+template <typename T>
+void CholeskyUpdateKernel(::sycl::nd_item<1> item, T* rMatrix, T* uVector,
+                          int nSize) {
+  const auto group = item.get_group();
+  const int local_id = static_cast<int>(item.get_local_id(0));
+  const int local_range = static_cast<int>(item.get_local_range(0));
+
+  // As per current work schedule, each work-item will
+  // handle a subset of the columns of the active row.
+  // kernel expects row-major, square upper-triangular matrix.
+  for (int k = 0; k < nSize; ++k) {
+    T c = 0;
+    T s = 0;
+
+    // Compute the row's coefficients in work-item 0 (column 0) and
+    // broadcast them to other work-items (columns) in the group.
+    if (local_id == 0) {
+      drotg(rMatrix + k * nSize + k, uVector + k, &c, &s);
+    }
+
+    c = ::sycl::group_broadcast(group, c, 0);
+    s = ::sycl::group_broadcast(group, s, 0);
+
+    for (int i = k + local_id; i < nSize; i += local_range) {
+      const T r = rMatrix[k * nSize + i];
+      const T u = uVector[i];
+      rMatrix[k * nSize + i] = c * r - s * u;
+      uVector[i] = s * r + c * u;
+    }
+
+    // The next row depends on this row's updates to uVector.
+    ::sycl::group_barrier(group);
+  }
+}
+}  // namespace
+
+template <typename T>
+void LaunchCholeskyUpdateFfiKernelBody(::sycl::queue& queue, T* matrix,
+                                       T* vector, int local_range, int nSize) {
+  // TODO(Intel-tf): Consider a root-group cooperative launch for multiple
+  // work-groups.
+  queue.submit([&](::sycl::handler& cgh) {
+    // Equal global and local ranges create exactly one work-group.
+    cgh.parallel_for(::sycl::nd_range<1>(local_range, local_range),
+                     [=](::sycl::nd_item<1> item) {
+                       CholeskyUpdateKernel(item, matrix, vector, nSize);
+                     });
+  });
+}
+
+absl::Status LaunchCholeskyUpdateFfiKernel(gpuStream_t stream, void* matrix,
+                                           void* vector, int size,
+                                           bool is_single_precision) {
+  ::sycl::queue& queue = *stream;
+  ::sycl::device device = queue.get_device();
+  const int max_work_group_size = static_cast<int>(
+      device.get_info<::sycl::info::device::max_work_group_size>());
+
+  // Use one work-group and distribute the active row's columns cyclically.
+  const int local_range = std::min(size, max_work_group_size);
+
+  if (is_single_precision) {
+    return JAX_AS_STATUS(TryCatchToStatus([&] {
+      LaunchCholeskyUpdateFfiKernelBody<float>(
+          *stream, static_cast<float*>(matrix), static_cast<float*>(vector),
+          local_range, size);
+    }));
+  }
+  return JAX_AS_STATUS(TryCatchToStatus([&] {
+    LaunchCholeskyUpdateFfiKernelBody<double>(
+        *stream, static_cast<double*>(matrix), static_cast<double*>(vector),
+        local_range, size);
+  }));
+}
+
+namespace {
+
+void ComputePermutation(const std::int32_t* pivots,
+                        std::int32_t* permutation_out,
+                        const std::int32_t pivot_size,
+                        const std::int32_t permutation_size) {
+  for (int i = 0; i < permutation_size; ++i) {
+    permutation_out[i] = i;
+  }
+
+  for (int i = 0; i < pivot_size; ++i) {
+    if ((pivots[i] < 0) || (pivots[i] >= permutation_size)) {
+      continue;
+    }
+    std::int32_t swap_temporary = permutation_out[i];
+    permutation_out[i] = permutation_out[pivots[i]];
+    permutation_out[pivots[i]] = swap_temporary;
+  }
+}
+
+void LuPivotsToPermutationKernel(::sycl::nd_item<1> item,
+                                 const std::int32_t* pivots,
+                                 std::int32_t* permutation_out,
+                                 const std::int64_t batch_size,
+                                 const std::int32_t pivot_size,
+                                 const std::int32_t permutation_size) {
+  for (std::int64_t idx = item.get_global_id(0); idx < batch_size;
+       idx += item.get_global_range(0)) {
+    ComputePermutation(pivots + idx * pivot_size,
+                       permutation_out + idx * permutation_size, pivot_size,
+                       permutation_size);
+  }
+}
+
+}  // namespace
+
+void LaunchLuPivotsToPermutationKernel(gpuStream_t stream,
+                                       std::int64_t batch_size,
+                                       std::int32_t pivot_size,
+                                       std::int32_t permutation_size,
+                                       const std::int32_t* pivots,
+                                       std::int32_t* permutation) {
+  const int local_range = 128;  // work-items per work-group
+  const std::int64_t num_work_groups = std::min<std::int64_t>(
+      1024, (batch_size + local_range - 1) / local_range);
+
+  absl::Status status = TryCatchToStatus([&] {
+    stream->submit([&](::sycl::handler& cgh) {
+      cgh.parallel_for(
+          ::sycl::nd_range<1>(num_work_groups * local_range, local_range),
+          [=](::sycl::nd_item<1> item) {
+            LuPivotsToPermutationKernel(item, pivots, permutation, batch_size,
+                                        pivot_size, permutation_size);
+          });
+    });
+  });
+  if (!status.ok()) {
+    LOG(ERROR) << "LaunchLuPivotsToPermutationKernel: " << status.message();
+  }
+}
+
+namespace {
+
+template <typename T>
+void TridiagonalSolvePerturbedKernel(::sycl::nd_item<1> item,
+                                     std::int64_t batch_size, int n, int k_rhs,
+                                     const T* subdiag, const T* diag,
+                                     const T* superdiag, const T* rhs, T* x,
+                                     T* workspace) {
+  for (std::int64_t idx = item.get_global_id(0); idx < batch_size;
+       idx += item.get_global_range(0)) {
+    T* u_workspace = workspace + idx * (n * 3 + k_rhs);
+    T* rhs_row_workspace = u_workspace + n * 3;
+    SolveWithGaussianEliminationWithPivotingAndPerturbSingular<T>(
+        n, k_rhs, subdiag + idx * n, diag + idx * n, superdiag + idx * n,
+        rhs + idx * n * k_rhs, x + idx * n * k_rhs, u_workspace,
+        rhs_row_workspace);
+  }
+}
+
+template <typename T>
+void LaunchTridiagonalSolvePerturbedKernelBody(
+    ::sycl::queue& queue, std::int64_t batch_size, int n, int k_rhs,
+    const void* subdiag, const void* diag, const void* superdiag,
+    const void* rhs, void* x, void* workspace) {
+  const int local_range = 128;  // work-items per work-group
+  const std::int64_t num_work_groups = std::min<std::int64_t>(
+      1024, (batch_size + local_range - 1) / local_range);
+
+  queue.submit([&](::sycl::handler& cgh) {
+    cgh.parallel_for(
+        ::sycl::nd_range<1>(num_work_groups * local_range, local_range),
+        [=](::sycl::nd_item<1> item) {
+          TridiagonalSolvePerturbedKernel<T>(
+              item, batch_size, n, k_rhs, static_cast<const T*>(subdiag),
+              static_cast<const T*>(diag), static_cast<const T*>(superdiag),
+              static_cast<const T*>(rhs), static_cast<T*>(x),
+              static_cast<T*>(workspace));
+        });
+  });
+}
+
+}  // namespace
+
+void LaunchTridiagonalSolvePerturbedKernel(
+    gpuStream_t stream, std::int64_t batch_size, int n, int k_rhs,
+    xla::ffi::DataType dtype, const void* subdiag, const void* diag,
+    const void* superdiag, const void* rhs, void* x, void* workspace) {
+  absl::Status status = TryCatchToStatus([&] {
+    switch (dtype) {
+      case xla::ffi::DataType::F32:
+        LaunchTridiagonalSolvePerturbedKernelBody<float>(
+            *stream, batch_size, n, k_rhs, subdiag, diag, superdiag, rhs, x,
+            workspace);
+        break;
+      case xla::ffi::DataType::F64:
+        LaunchTridiagonalSolvePerturbedKernelBody<double>(
+            *stream, batch_size, n, k_rhs, subdiag, diag, superdiag, rhs, x,
+            workspace);
+        break;
+      case xla::ffi::DataType::C64:
+        LaunchTridiagonalSolvePerturbedKernelBody<std::complex<float>>(
+            *stream, batch_size, n, k_rhs, subdiag, diag, superdiag, rhs, x,
+            workspace);
+        break;
+      case xla::ffi::DataType::C128:
+        LaunchTridiagonalSolvePerturbedKernelBody<std::complex<double>>(
+            *stream, batch_size, n, k_rhs, subdiag, diag, superdiag, rhs, x,
+            workspace);
+        break;
+      default:
+        break;
+    }
+  });
+  if (!status.ok()) {
+    LOG(ERROR) << "LaunchTridiagonalSolvePerturbedKernel: " << status.message();
+  }
+}
+
+}  // namespace JAX_GPU_NAMESPACE
+}  // namespace jax

--- a/jaxlib/gpu_linalg.py
+++ b/jaxlib/gpu_linalg.py
@@ -18,14 +18,17 @@ from .plugin_support import import_from_plugin
 
 _cuda_linalg = import_from_plugin("cuda", "_linalg")
 _hip_linalg = import_from_plugin("rocm", "_linalg")
+_oneapi_linalg = import_from_plugin("oneapi", "_linalg")
 
 
 def registrations() -> dict[str, list[tuple[str, Any, int]]]:
   registrations: dict[str, list[tuple[str, Any, int]]] = {
       "CUDA": [],
       "ROCM": [],
+      "ONEAPI": [],
   }
-  for platform, module in [("CUDA", _cuda_linalg), ("ROCM", _hip_linalg)]:
+  for platform, module in [("CUDA", _cuda_linalg), ("ROCM", _hip_linalg),
+                           ("ONEAPI", _oneapi_linalg)]:
     if module:
       registrations[platform].extend(
           (*i, 1) for i in module.registrations().items()
@@ -39,4 +42,6 @@ def batch_partitionable_targets() -> list[str]:
     targets.append("cu_lu_pivots_to_permutation")
   if _hip_linalg:
     targets.append("hip_lu_pivots_to_permutation")
+  if _oneapi_linalg:
+    targets.append("oneapi_lu_pivots_to_permutation")
   return targets

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -216,11 +216,67 @@ nanobind_extension(
     ],
 )
 
+sycl_library(
+    name = "oneapi_linalg_kernels_impl",
+    srcs = ["//jaxlib/gpu:linalg_kernels_oneapi.cc"],
+    hdrs = ["//jaxlib/gpu:linalg_kernels.h"],
+    local_defines = [
+        "EIGEN_USE_SYCL=1",
+        "EIGEN_DONT_VECTORIZE_SYCL=1",
+    ],
+    copts = [
+        "-U_FORTIFY_SOURCE",
+        "-D_FORTIFY_SOURCE=0",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_vendor",
+        "//jaxlib:tridiagonal_solve_perturbed",
+        "@xla//xla/ffi/api:ffi",
+    ],
+)
+
+sycl_library(
+    name = "oneapi_linalg_kernels",
+    srcs = ["//jaxlib/gpu:linalg_kernels.cc"],
+    hdrs = ["//jaxlib/gpu:linalg_kernels.h"],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_linalg_kernels_impl",
+        ":oneapi_vendor",
+        ":oneapi_gpu_runtime",
+        "//jaxlib:ffi_helpers",
+        "@com_google_absl//absl/strings:str_format",
+        "@xla//xla/ffi/api:ffi",
+    ],
+)
+
+nanobind_extension(
+    name = "_linalg",
+    srcs = ["//jaxlib/gpu:linalg.cc"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    module_name = "_linalg",
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_linalg_kernels",
+        ":oneapi_vendor",
+        "//jaxlib:kernel_nanobind_helpers",
+        "@nanobind",
+    ],
+)
+
 py_library(
     name = "oneapi_gpu_support",
     deps = [
         ":_prng",
         ":_solver",
+        ":_linalg",
         ":_hybrid",
     ],
 )

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -247,6 +247,7 @@ def prepare_wheel_oneapi(
   copy_files(
       dst_dir=plugin_dir,
       src_files=[
+          f"{source_file_prefix}jaxlib/oneapi/_linalg.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_hybrid.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_prng.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_solver.{pyext}",

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2640,6 +2640,10 @@ class LaxLinalgTest(jtu.JaxTestCase):
     if jtu.is_device_rocm() and not perturb_singular:
       self.skipTest(
           "Skipped on ROCm: hipsparseSgtsv2 numerical error on pivoting path.")
+    # OneAPI's non-perturbed path uses the non-pivoting Thomas decomposition.
+    if jtu.test_device_matches(["oneapi"]) and not perturb_singular:
+      self.skipTest(
+          "OneAPI non-perturbed path uses the non-pivoting fallback solver.")
     dl = np.array([0.0, 2.0, -2.0, 3.0], dtype=np.float32)
     d = np.array([1.0, 4.0, 1.0, -1.0], dtype=np.float32)
     du = np.array([2.0, -1.0, 1.0, 0.0], dtype=np.float32)
@@ -2658,6 +2662,9 @@ class LaxLinalgTest(jtu.JaxTestCase):
     if jtu.is_device_rocm() and not perturb_singular:
       self.skipTest(
           "Skipped on ROCm: hipsparseSgtsv2 numerical error on pivoting path.")
+    if jtu.test_device_matches(["oneapi"]) and not perturb_singular:
+      self.skipTest(
+          "OneAPI non-perturbed path uses the non-pivoting fallback solver.")
     dl = np.array([0.0, 1.0, -6.0, 1.0], dtype=np.float32)
     d = np.array([1.0, -1.0, 2.0, 1.0], dtype=np.float32)
     du = np.array([2.0, 1.0, -1.0, 0.0], dtype=np.float32)


### PR DESCRIPTION
This PR adds following changes:

1. Adds SYCL/OneAPI Kernel implementations for three JAX linalg operations (`jaxlib/gpu/linalg_kernels_oneapi.cc`)
    - LU pivots to permutation `jax.lax.linalg.lu_pivots_to_permutation`
    - Cholesky update Kernel `jax.lax.linalg.cholesky_update`
    - Tridiagonal solve with `perturb_singular=True` `jax.lax.linalg.tridiagonal_solve(...,perturb_singular=True)` 
2. Adds OneAPI FFI registrations and lowering rules for above operations and required build targets. 
    

Tests
```
tests/linalg_test.py --test_targets="testLuPivotsToPermutation"
tests/cholesky_update_test.py
tests/linalg_test.py --test_targets="tridiagonal_solve"
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->