### PR TITLE
[ROCm] Run ROCm RBE bazel tests remotely

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -28,7 +28,7 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        default: "amd-do-linux.jax.gpu.gfx950.1"
+        default: "amd-do-linux.jax.cpu"
       python:
         description: "Which python version to test?"
         type: string
@@ -127,12 +127,7 @@ jobs:
       image: ghcr.io/rocm/jax-base-ubu24.${{ inputs.rocm-tag }}:latest  # zizmor: ignore[unpinned-images]
       volumes:
         - /data:/data
-      options: >-
-        --device=/dev/kfd
-        --device=/dev/dri
-        --group-add video
-        --shm-size 64G
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --shm-size 64G
 
     env:
       JAXCI_CLONE_MAIN_XLA: ${{ inputs.clone_main_xla }}
@@ -152,18 +147,6 @@ jobs:
         with:
           ref: ${{ inputs.git_commit }}
           persist-credentials: false
-      - name: ROCm Info
-        run: |
-          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
-          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
-          # rocm-sdk and already have rocminfo on PATH.
-          if command -v rocm-sdk >/dev/null 2>&1; then
-            sdk_bin="$(rocm-sdk path --bin)"
-            if [[ -n "$sdk_bin" ]]; then
-              export PATH="$sdk_bin:$PATH"
-            fi
-          fi
-          rocminfo
       - name: Configure AWS Credentials
         if: inputs.build_jaxlib == 'false' && inputs.jaxlib-version == 'head'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -219,7 +202,6 @@ jobs:
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh  \
             --config="${GPU_CONFIG}" \
-            --local_test_jobs=4 \
             --//jax:build_jaxlib="${BUILD_JAXLIB}" \
             --//jax:build_jax="${BUILD_JAX}" \
             --repo_env=HERMETIC_PYTHON_VERSION="${PYTHON}" \

--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -35,7 +35,7 @@ jobs:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
           python: ["3.14"]
-          runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+          runner: ["amd-do-linux.jax.cpu"]
           jaxlib-version: ["head", "pypi_latest"]
           enable-x64: [0]
           rocm-version: ["10"]
@@ -65,9 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12"]
-        runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+        runner: ["amd-do-linux.jax.cpu"]
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
-    name: "ROCm blocking gate"
+    name: "${{ matrix.runner && 'ROCm blocking gate' }}"
 # End Presubmit Naming Check github-rocm-blocking-presubmits
     with:
       runner: ${{ matrix.runner }}

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -583,7 +583,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.4"]
+          runner: ["amd-do-linux.jax.cpu"]
           python: ["3.12"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},
@@ -623,7 +623,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.4"]
+          runner: ["amd-do-linux.jax.cpu"]
           python: ["3.12"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -288,7 +288,7 @@ jobs:
     strategy:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+          runner: ["amd-do-linux.jax.cpu"]
           python: ["3.12", "3.13", "3.14", "3.15"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},

--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -73,26 +73,10 @@ build:rocm_rbe --remote_download_outputs=minimal
 
 test:rocm_rbe --remote_timeout=3600
 test:rocm_rbe --jobs=64
-test:rocm_rbe --strategy=TestRunner=remote,local
+# No local fallback: the runners for this config have no GPU.
+test:rocm_rbe --strategy=TestRunner=remote
 test:rocm_rbe --worker_sandboxing=true
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
-
-# Dynamic execution config for ROCm RBE - builds locally, tests use hybrid mode
-common:rocm_rbe_dynamic --config=rocm_rbe
-# Keep builds local (inherit from rocm_rbe)
-build:rocm_rbe_dynamic --spawn_strategy=local
-# Enable dynamic execution for tests only
-test:rocm_rbe_dynamic --experimental_spawn_scheduler
-test:rocm_rbe_dynamic --strategy=TestRunner=dynamic
-test:rocm_rbe_dynamic --dynamic_mode=default
-# Configure local and remote strategies for dynamic test execution
-test:rocm_rbe_dynamic --dynamic_local_strategy=worker,standalone,local
-test:rocm_rbe_dynamic --dynamic_remote_strategy=remote
-# Delay before starting local test execution (ms) - adjust to prefer remote or local
-# Lower values = more local execution, higher values = more remote execution
-test:rocm_rbe_dynamic --experimental_local_execution_delay=1000
-# Maximum number of test jobs to run locally in parallel (50% of available CPUs)
-test:rocm_rbe_dynamic --local_resources=cpu=HOST_CPUS*0.5
 
 # Used for rules_python bootstrap 1.8.0+
 build --@rules_python//python/config_settings:bootstrap_impl=script --repo_env=RULES_PYTHON_ENABLE_PIPSTAR=0

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -77,7 +77,7 @@ echo "::group::Bazel ROCm RBE tests" >&2
 bazel --bazelrc=build/rocm/rocm.bazelrc test \
     --profile="$TEST_ARTIFACTS_DIR/bazel_profile.json.gz" \
     --config=rocm_clang_hermetic \
-    --config=rocm_rbe_dynamic \
+    --config=rocm_rbe \
     $OVERRIDE_XLA_REPO \
     --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
     --test_output=errors \
@@ -91,7 +91,6 @@ bazel --bazelrc=build/rocm/rocm.bazelrc test \
     --color=yes \
     "${ROCM_SDK_FLAGS[@]}" \
     $@ \
-    --spawn_strategy=local \
     --target_pattern_file="${TARGETS_FILE}" || bazel_retval=$?
 echo "::endgroup::" >&2
 


### PR DESCRIPTION
Make ROCm bazel CI legs run their tests on RBE workers instead of racing them
locally with the dynamic scheduler, and the jobs move to CPU runners since they
only build wheels locally.