### PR TITLE
Fix jnp.trapezoid on an empty integration axis

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6521,8 +6521,9 @@ def trapezoid(y: ArrayLike, x: ArrayLike | None = None, dx: ArrayLike = 1.0,
     else:
       dx_array = moveaxis(diff(x_arr, axis=axis), axis, -1)
   y_arr = moveaxis(y_arr, axis, -1)
-  # Fast path: dx is constant along the integration axis.
-  if dx_array.ndim == 0 or dx_array.shape[-1] == 1:
+  # Fast path: dx is constant along the integration axis. It relies on the
+  # first and last elements existing, so it does not apply to an empty axis.
+  if y_arr.shape[-1] > 0 and (dx_array.ndim == 0 or dx_array.shape[-1] == 1):
     dx_reduced = dx_array if dx_array.ndim == 0 else dx_array[..., 0]
     return dx_reduced * (y_arr.sum(-1) - 0.5 * (y_arr[..., 0] + y_arr[..., -1]))
   return 0.5 * (dx_array * (y_arr[..., 1:] + y_arr[..., :-1])).sum(-1)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6340,6 +6340,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ((3, 10), (10,), 1.0, -1),
         ((3, 10), (3, 10), 1.0, -1),
         ((2, 3, 10), (3, 10), 1.0, -2),
+        # empty integration axis: the result is zero, as in numpy.
+        ((0,), None, 1.0, -1),
+        ((3, 0), None, 1.0, -1),
+        ((0, 3), None, 1.0, 0),
       ]
     ],
     dtype=float_dtypes + int_dtypes,


### PR DESCRIPTION
The fast path added for constant dx reads y[..., 0] and y[..., -1], which raises IndexError when the integration axis is empty. numpy returns 0.0 for this input, and the general path below already produces 0.0, so the fast path simply should not apply when the axis has no elements.

Adds empty-axis shapes to the existing test_trapezoid parametrisation.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->