### PR TITLE
Typo fix: changed artifact name from bazel-cuda-h100 to bazel-cuda-b200

### DIFF
--- a/.github/workflows/bazel_cuda_h100_b200.yml
+++ b/.github/workflows/bazel_cuda_h100_b200.yml
@@ -131,7 +131,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/upload-test-artifacts
         with:
-          artifact-name: bazel-cuda-h100-single
+          artifact-name: bazel-cuda-b200-single
           inputs_json: ${{ toJSON(inputs) }}
           matrix_json: ${{ toJSON(matrix) }}
   run_multiaccelerator_tests:


### PR DESCRIPTION
The job name: `name: "Bazel single B200 CUDA tests"` but the name of the artifact to upload mentions h100, changed the typo