### PR TITLE
fix(checkify): harmonize error code dtypes in update_error (fixes #40482)

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -325,7 +325,18 @@ def assert_func(ctx: CheckifyContext, error: Error, pred: Bool,
 def update_error(error, pred, code, metadata, payload, effect_type):
   err_of_type = error._pred.get(effect_type, False)
   out_err = err_of_type | pred
-  out_code = lax.select(err_of_type, error._code.get(effect_type, _INACTIVE_CODE), code)
+  prev_code = error._code.get(effect_type, None)
+  if prev_code is None:
+    prev_code = lax.full_like(code, _INACTIVE_CODE)
+  code_dtype = dtypes.result_type(prev_code, code)
+  prev_code = lax.convert_element_type(prev_code, code_dtype)
+  code = lax.convert_element_type(code, code_dtype)
+  if np.shape(prev_code) != np.shape(code):
+    if not np.shape(prev_code):
+      prev_code = lax.broadcast(prev_code, np.shape(code))
+    elif not np.shape(code):
+      code = lax.broadcast(code, np.shape(prev_code))
+  out_code = lax.select(err_of_type, prev_code, code)
   cur_payload = error._payload.get(effect_type, None)
   if cur_payload is not None:
     out_payload = tree_map(functools.partial(lax.select, err_of_type), cur_payload, payload)

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -1611,6 +1611,25 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     self.assertIsNotNone(err_out.get())
     self.assertStartsWith(err_out.get(), "post-while check")
 
+  def test_checkify_enable_x64_scope(self):
+    # Regression test for https://github.com/google/jax/issues/40482
+    def f(x):
+      with jax.enable_x64():
+        checkify.check(x > 0, "positive")
+        return x
+
+    err, out = checkify.checkify(f)(jnp.ones((), dtype=jnp.float64))
+    self.assertIsNone(err.get())
+    self.assertEqual(out, 1.0)
+
+    err, out = jax.jit(checkify.checkify(f))(jnp.ones((), dtype=jnp.float64))
+    self.assertIsNone(err.get())
+    self.assertEqual(out, 1.0)
+
+    err, _ = jax.jit(checkify.checkify(f))(jnp.array(-1.0, dtype=jnp.float64))
+    self.assertIsNotNone(err.get())
+    self.assertStartsWith(err.get(), "positive")
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
### Problem
Fixes #40482.

When a function traced by `checkify` contains a `with jax.enable_x64():` scope, error codes created or traced inside the scope take `int64` dtype (when `jax_explicit_x64_dtypes="allow"`). When the function returns and the error is discharged via `update_error` in `jax/_src/checkify.py`:
```python
out_code = lax.select(err_of_type, error._code.get(effect_type, _INACTIVE_CODE), code)
```
If `effect_type` was not yet in `error._code`, `_INACTIVE_CODE = -2` was passed as a Python `int` literal. Outside the `enable_x64` scope, `lax.select` evaluates `-2` with default `int32` dtype while `code` is `int64`, causing `lax.select` to fail with:
```
TypeError: lax.select requires arguments to have the same dtypes, got int64, int32.
```
A similar mismatch can occur if multiple checks of the same effect type are executed under differing x64 contexts.

### Solution
In `update_error()`:
1. Initialize absent previous error codes using `lax.full_like(code, _INACTIVE_CODE)` so the inactive placeholder naturally adopts the shape and dtype of `code`.
2. Compute the promoted result dtype `code_dtype = dtypes.result_type(prev_code, code)` and convert both operands using `lax.convert_element_type()` prior to `lax.select()`.
3. Ensure operand shapes match by broadcasting if one operand is a scalar.

### Testing
- Added regression test `test_checkify_enable_x64_scope` in `tests/checkify_test.py` covering both eager and `jax.jit` execution with `with jax.enable_x64()` inside the checkified function.
- Verified with `ruff check` on both modified files.
