### PR TITLE
fix(nn): add custom_jvp for log_softmax to prevent NaN gradients (fixes #40409)

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1487,8 +1487,8 @@ softmax_custom_jvp = bool_state(
     name='jax_softmax_custom_jvp',
     default=False,
     upgrade=True,
-    help=('Use a new custom_jvp rule for jax.nn.softmax. The new rule should '
-          'improve memory usage and stability. Set True to use new '
+    help=('Use a new custom_jvp rule for jax.nn.softmax and jax.nn.log_softmax. '
+          'The new rule should improve memory usage and stability. Set True to use new '
           'behavior. See https://github.com/jax-ml/jax/pull/15677'),
     include_in_jit_key=True,
     include_in_trace_context=True)

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -536,7 +536,8 @@ def logmeanexp(
 @api.jit(static_argnames=("axis",))
 def log_softmax(x: ArrayLike,
                 axis: Axis = -1,
-                where: ArrayLike | None = None) -> Array:
+                where: ArrayLike | None = None,
+                initial: ArrayLike = -np.inf) -> Array:
   r"""Log-Softmax function.
 
   Computes the logarithm of the :code:`softmax` function, which rescales
@@ -552,6 +553,7 @@ def log_softmax(x: ArrayLike,
       computed. Either an integer, tuple of integers, or ``None`` (all axes).
     where: Elements to include in the :code:`log_softmax`. The output for any
       masked-out element is minus infinity.
+    initial: The minimum value used to shift the input array. Optional.
 
   Returns:
     An array.
@@ -563,8 +565,49 @@ def log_softmax(x: ArrayLike,
   See also:
     :func:`softmax`
   """
+  if config.softmax_custom_jvp.value:
+    return _log_softmax(x, axis, where, initial)
+  else:
+    return _log_softmax_deprecated(x, axis, where, initial)
+
+
+# TODO(mattjj): replace log_softmax with _log_softmax when deprecation flag is removed
+@partial(custom_derivatives.custom_jvp, nondiff_argnums=(1,))
+def _log_softmax(
+    x: ArrayLike,
+    axis: Axis = -1,
+    where: ArrayLike | None = None,
+    initial: ArrayLike = -np.inf) -> Array:
   x_arr = numpy_util.ensure_arraylike("log_softmax", x)
-  x_max = jnp.max(x_arr, axis, where=where, initial=-np.inf, keepdims=True)
+  x_max = jnp.max(x_arr, axis, where=where, initial=initial, keepdims=True)
+  x_safe = x_arr if where is None else jnp.where(where, x_arr, initial)
+  shifted = x_safe - x_max
+  shifted_logsumexp = jnp.log(
+      jnp.sum(jnp.exp(shifted), axis, where=where, keepdims=True))
+  result = shifted - shifted_logsumexp
+  if where is not None:
+    return jnp.where(where, result, -np.inf)
+  return result
+
+
+@_log_softmax.defjvp
+def _log_softmax_jvp(axis, primals, tangents):
+  (x, where, initial), (x_dot, _, _) = primals, tangents
+  y = _log_softmax(x, axis, where, initial)
+  p = _softmax(x, axis, where, initial)
+  y_dot = x_dot - (p * x_dot).sum(axis, where=where, keepdims=True)
+  if where is not None:
+    y_dot = jnp.where(where, y_dot, 0)
+  return y, y_dot
+
+
+def _log_softmax_deprecated(
+    x: ArrayLike,
+    axis: Axis = -1,
+    where: ArrayLike | None = None,
+    initial: ArrayLike = -np.inf) -> Array:
+  x_arr = numpy_util.ensure_arraylike("log_softmax", x)
+  x_max = jnp.max(x_arr, axis, where=where, initial=initial, keepdims=True)
   x_safe = x_arr if where is None else jnp.where(where, x_arr, -np.inf)
   shifted = x_safe - lax.stop_gradient(x_max)
   shifted_logsumexp = jnp.log(
@@ -579,7 +622,8 @@ def log_softmax(x: ArrayLike,
 # @api.jit(static_argnames=("axis",))
 def softmax(x: ArrayLike,
             axis: Axis = -1,
-            where: ArrayLike | None = None) -> Array:
+            where: ArrayLike | None = None,
+            initial: ArrayLike = -np.inf) -> Array:
   r"""Softmax function.
 
   Computes the function which rescales elements to the range :math:`[0, 1]`
@@ -595,6 +639,7 @@ def softmax(x: ArrayLike,
       Either an integer, tuple of integers, or ``None`` (all axes).
     where: Elements to include in the :code:`softmax`. The output for any
       masked-out element is zero.
+    initial: The minimum value used to shift the input array. Optional.
 
   Returns:
     An array.
@@ -607,9 +652,9 @@ def softmax(x: ArrayLike,
     :func:`log_softmax`
   """
   if config.softmax_custom_jvp.value:
-    return _softmax(x, axis, where)
+    return _softmax(x, axis, where, initial)
   else:
-    return _softmax_deprecated(x, axis, where)
+    return _softmax_deprecated(x, axis, where, initial)
 
 # TODO(mattjj): replace softmax with _softmax when deprecation flag is removed
 @partial(custom_derivatives.custom_jvp, nondiff_argnums=(1,))

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -622,11 +622,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
     probs = out if fn is nn.softmax else jnp.exp(out)
     self.assertAllClose(probs.sum(), 1.0)
 
-    # TODO(mattjj): include log_softmax in these extra tests if/when we add a
-    # custom_jvp rule for it (since otherwise it doesn't pass the numerical
-    # checks below).
-    if fn is nn.softmax and config.softmax_custom_jvp.value:
-      g_fun = lambda x: jnp.take(fn(x, where=m, initial=-jnp.inf),
+    if config.softmax_custom_jvp.value:
+      g_fun = lambda x: jnp.take(fn(x, where=m),
                                 jnp.array([0, 2, 3]))
       jtu.check_grads(g_fun, (x,), order=2)
 
@@ -663,6 +660,29 @@ class NNFunctionsTest(jtu.JaxTestCase):
       res = ad_checkpoint.saved_residuals(nn.softmax, x)
     self.assertLen(res, 1)
     self.assertEqual(sum(a.size for a, _ in res), 4)
+
+  def testLogSoftmaxGrad(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    with jax.softmax_custom_jvp(True):
+      jtu.check_grads(nn.log_softmax, (x,), order=2, atol=5e-3)
+
+  def testLogSoftmaxGradResiduals(self):
+    if not config.softmax_custom_jvp.value:
+      raise unittest.SkipTest("only applies when upgrade flag enabled")
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    res = ad_checkpoint.saved_residuals(nn.log_softmax, x)
+    self.assertLen(res, 1)
+
+  def testLogSoftmaxGradFlag(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+
+    with jax.softmax_custom_jvp(False):
+      res = ad_checkpoint.saved_residuals(nn.log_softmax, x)
+    self.assertLen(res, 3)
+
+    with jax.softmax_custom_jvp(True):
+      res = ad_checkpoint.saved_residuals(nn.log_softmax, x)
+    self.assertLen(res, 1)
 
   def testStandardizeWhereMask(self):
     x = jnp.array([5.5, 1.3, -4.2, 0.9])


### PR DESCRIPTION
Fixes #40409

### Motivation and Context
`jax.grad` through `log_softmax` on large arrays (~2^16+ elements, e.g. float16) previously produced `NaN` gradients due to intermediate exponentiation sums in the forward pass causing indeterminate forms (`0 * inf`) during reverse-mode autodiff.

As noted in `tests/nn_test.py:625`:
> `# TODO(mattjj): include log_softmax in these extra tests if/when we add a custom_jvp rule for it (since otherwise it doesn't pass the numerical checks below).`

### Description of Changes
1. Added `_log_softmax` with `@partial(custom_derivatives.custom_jvp, nondiff_argnums=(1,))` and its accompanying `_log_softmax_jvp` rule:
   $$\dot{y} = \dot{x} - \sum (\mathrm{softmax}(x) \cdot \dot{x})$$
   which is numerically stable and avoids intermediate `exp` gradient overflows.
2. Wired `log_softmax` to delegate to `_log_softmax` when `config.softmax_custom_jvp.value` is enabled, preserving backward compatibility via `_log_softmax_deprecated`.
3. Updated `jax.nn.softmax` and `jax.nn.log_softmax` signatures to accept optional `initial: ArrayLike = -np.inf`.
4. Resolved the TODO in `tests/nn_test.py` by enabling second-order gradient checks for `log_softmax` under `testSoftmaxWhereMask`, and added `testLogSoftmaxGrad`, `testLogSoftmaxGradResiduals`, and `testLogSoftmaxGradFlag`.
