### PR TITLE
Singleton dimension rank reduction support

### DIFF
--- a/jax/experimental/mosaic/gpu/constraints.py
+++ b/jax/experimental/mosaic/gpu/constraints.py
@@ -230,6 +230,13 @@ def reduce_reshape_expression(
               )
           )
         case fa.TiledLayout() as tiled_layout:
+          # Reshapes that only add or remove size-1 dimensions are a pure
+          # relabeling of the layout, and are allowed to change the rank.
+          degenerate = fa.degenerate_reshape(
+              tiled_layout, reshape.source_shape, reshape.target_shape
+          )
+          if degenerate is not None:
+            return RegisterLayout(degenerate)
           tile_shape = tiled_layout.base_tile_shape
           if len(reshape.target_shape) < len(tile_shape):
             return dataclasses.replace(reshape, expression=reduced_expr)

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -545,6 +545,43 @@ class TiledLayout:
         _check_canonical=False,
     ).canonicalize()
 
+  def insert_dimension(self, dim: int) -> TiledLayout:
+    """Returns a layout with a size-1 dimension inserted at `dim`.
+
+    This is the inverse of `remove_dimension` for a size-1 dimension. Tile ranks
+    are nested (each tile covers the trailing dimensions of the previous one),
+    so which tiles originally spanned the inserted dimension is ambiguous. We
+    insert into every tile that spans it: a tile that did not gets a leading
+    `1`, which `canonicalize` trims back off.
+    """
+    if dim < 0 or dim > len(self.tiling.tiles[0]):
+      raise ValueError(f"Dimension {dim} is out of range for {self.tiling}")
+    tiles, dim_in_tile, last_rank = [], dim, len(self.tiling.tiles[0]) + 1
+    for t in self.tiling.tiles:
+      i = dim_in_tile - (last_rank - len(t) - 1)
+      if i >= 0:
+        t, dim_in_tile = t[:i] + (1,) + t[i:], i
+      else:
+        dim_in_tile -= last_rank - len(t)
+      last_rank = len(t)
+      tiles.append(t)
+    new_tiling = Tiling(tuple(tiles))
+    # The inserted dimension contributes exactly the size-1 entries flagged
+    # here; every other entry keeps its order, so it only needs reindexing.
+    inserted_dim = new_tiling.tile_dimension(dim)
+    kept = [i for i, ins in enumerate(inserted_dim) if not ins]
+    def replace_tiled_dim(d: int | Replicated):
+      if isinstance(d, Replicated):
+        return d
+      return kept[d + len(kept)] - len(inserted_dim)
+    return TiledLayout(
+        new_tiling,
+        tuple(replace_tiled_dim(d) for d in self.warp_dims),
+        tuple(replace_tiled_dim(d) for d in self.lane_dims),
+        replace_tiled_dim(self.vector_dim),
+        _check_canonical=False,
+    ).canonicalize()
+
   def reduce(self, axes: Sequence[int]) -> TiledLayout:
     reduced_layout = self
     for a in sorted(axes, reverse=True):
@@ -658,6 +695,55 @@ class TiledLayout:
       if isinstance(dim, Replicated):
         replication_factor *= dim.times
     return replication_factor
+
+
+def degenerate_reshape(
+    layout: TiledLayout,
+    source_shape: tuple[int, ...],
+    target_shape: tuple[int, ...],
+) -> TiledLayout | None:
+  """Adapts `layout` to `target_shape`, if the reshape only adds/removes 1s.
+
+  Size-1 dimensions only ever occupy size-1 entries of the tiled shape, so
+  adding or removing them is a pure relabeling of the layout: the registers are
+  unchanged. Returns `None` if the reshape does anything else, in which case
+  the caller has to fall back to a layout change.
+  """
+  if source_shape == target_shape:
+    return layout
+  if [d for d in source_shape if d != 1] != [d for d in target_shape if d != 1]:
+    return None
+
+  def degenerate_axes(shape, other):
+    """The axes of `shape` (all size 1) that `other` does not have."""
+    axes, matched = [], 0
+    for axis, d in enumerate(shape):
+      if matched < len(other) and other[matched] == d:
+        matched += 1
+      else:
+        axes.append(axis)
+    return tuple(axes) if matched == len(other) else None
+
+  # The tiling only describes the trailing dimensions; leading ones are merely
+  # replicated over registers, so adding or removing them is a no-op.
+  untiled = len(source_shape) - len(layout.base_tile_shape)
+  if untiled < 0:
+    return None
+
+  if len(source_shape) > len(target_shape):
+    if (axes := degenerate_axes(source_shape, target_shape)) is None:
+      return None
+    return layout.reduce(tuple(a - untiled for a in axes if a >= untiled))
+  if len(source_shape) < len(target_shape):
+    if (axes := degenerate_axes(target_shape, source_shape)) is None:
+      return None
+    for axis in sorted(axes):  # Ascending, so `untiled` stays in step.
+      if axis < untiled:
+        untiled += 1
+      else:
+        layout = layout.insert_dimension(axis - untiled)
+    return layout
+  return None  # Same rank, but the 1s moved around.
 
 
 def _tiled_wgmma_layout(shape: tuple[int, ...]):
@@ -3418,6 +3504,17 @@ class FragmentedArray:
             _is_signed=self.is_signed,
         )
       case TiledLayout():
+        # Adding or removing size-1 dimensions is a pure relabeling of the
+        # layout, even when it changes the rank of the base tile.
+        new_layout = degenerate_reshape(self.layout, self.shape, shape)
+        if new_layout is not None:
+          return FragmentedArray(
+              _registers=self.registers.reshape(
+                  new_layout.registers_shape(shape)
+              ),
+              _layout=new_layout,
+              _is_signed=self.is_signed,
+          )
         base_tile_shape = self.layout.base_tile_shape
         assert base_tile_shape
         old_shape_suffix = self.shape[-len(base_tile_shape):]

--- a/tests/mosaic/gpu_constraints_test.py
+++ b/tests/mosaic/gpu_constraints_test.py
@@ -370,6 +370,55 @@ class ConstraintSystemTest(parameterized.TestCase):
     eq = cs.Reshape(layout, source_shape, target_shape)
     self.assertEqual(cs.reduce_expression(eq, {}), layout)
 
+  def test_reduce_reshape_of_tiled_layout_over_untiled_degenerate_dim_is_identity(
+      self,
+  ):
+    layout = RL(mgpu.WGMMA_LAYOUT)
+    eq = cs.Reshape(layout, (1, 128, 8), (128, 8))
+    self.assertEqual(cs.reduce_expression(eq, {}), layout)
+
+  # Layouts whose base tile spans every dimension, so that dropping a
+  # degenerate dimension changes the rank of the tiling itself.
+  @parameterized.parameters(
+      (
+          fa.TiledLayout(
+              fa.Tiling(((32, 128, 1), (32, 32, 1), (8, 4, 1))),
+              warp_dims=(-8,),
+              lane_dims=(-6, -5),
+              vector_dim=-2,
+          ),
+          (32, 128, 1),
+          (32, 128),
+          (2,),
+      ),
+      (
+          fa.TiledLayout(
+              fa.Tiling(((1, 128, 128), (32, 128), (32, 4))),
+              warp_dims=(-6,),
+              lane_dims=(-3,),
+              vector_dim=-1,
+          ),
+          (1, 128, 128),
+          (128, 128),
+          (0,),
+      ),
+  )
+  def test_reduce_reshape_of_tiled_layout_over_tiled_degenerate_dim(
+      self, tiled, source_shape, target_shape, dropped_dims
+  ):
+    squeezed = tiled.reduce(dropped_dims)
+
+    self.assertEqual(
+        cs.reduce_expression(cs.Reshape(RL(tiled), source_shape, target_shape), {}),
+        RL(squeezed),
+    )
+    # And back the other way, which is the direction that lets inference
+    # recover the source layout from the result of the reshape.
+    self.assertEqual(
+        cs.reduce_expression(cs.Reshape(RL(squeezed), target_shape, source_shape), {}),
+        RL(tiled),
+    )
+
   def test_reduce_strict_relayout_produces_equals_constraint(self):
     layout = RL(mgpu.WGStridedFragLayout((128, 128), vec_size=1))
     relayout = cs.Relayout(layout, V(0), 32, strict=True)


### PR DESCRIPTION
Fixes #40610 

In Mosaic GPU, the layout inference rule for `shape_cast` (`Reshape` in
`jax/experimental/mosaic/gpu/constraints.py`) refuses to propagate a
`TiledLayout` whenever the reshape changes the rank of the base tile. This
blocks the common case of adding or removing size-1 dimensions, which is a pure
relabeling of the layout and does not move a single register. This PR adds support
for `shape_cast` rank reductions when only singleton dimensions are removed. 