### PR TITLE
Bumped tol for tan op for complex64 to fix failing testOpAgainstNumpy

### DIFF
--- a/jax/_src/internal_test_util/lax_test_util.py
+++ b/jax/_src/internal_test_util/lax_test_util.py
@@ -257,7 +257,10 @@ def lax_ops():
           1,
           float_dtypes + complex_dtypes,
           test_util.rand_default,
-          {np.float32: 3e-5},
+          {
+            np.float32: 3e-5,
+            np.complex64: 1e-6 if config.enable_x64.value else 3e-5
+          },
       ),
       op_record(
           "asin",


### PR DESCRIPTION
The test is failing on windows only (but tol bump is for any platform). 
```
AssertionError:
  Not equal to tolerance rtol=1e-06, atol=1e-06

  Mismatched elements: 1 / 12 (8.33%)
  Max absolute difference among violations: 1.9499375e-05
  Max relative difference among violations: 1.146967e-06
   ACTUAL: array([[ 2.036875e-05 -1.00002j , -3.520507e-05 +0.999941j,
          -3.129646e-04 -1.000307j,  1.008898e-03 -1.000536j],
         [-2.205016e-03 -1.00307j , -1.525633e-05 +0.999992j,...
   DESIRED: array([[ 2.036875e-05 -1.00002j , -3.520507e-05 +0.999941j,
          -3.129646e-04 -1.000307j,  1.008898e-03 -1.000536j],
         [-2.205016e-03 -1.00307j , -1.525633e-05 +0.999992j,...
```
Test:
```
FAIL: testOpAgainstNumpy543 (op_name='tan', rng_factory=<function rand_default at 0x000001F42DD2E7A0>, tol={<class 'numpy.float32'>: 3e-05}, shapes=((3, 4),), dtype=<class 'numpy.complex64'>) (__main__.LaxTest)
  LaxTest.testOpAgainstNumpy543 (op_name='tan', rng_factory=<function rand_default at 0x000001F42DD2E7A0>, tol={<class 'numpy.float32'>: 3e-05}, shapes=((3, 4),), dtype=<class 'numpy.complex64'>)
  testOpAgainstNumpy(op_name='tan', rng_factory=<function rand_default at 0x000001F42DD2E7A0>, tol={<class 'numpy.float32'>: 3e-05}, shapes=((3, 4),), dtype=<class 'numpy.complex64'>)
```
Job name: Bazel CPU tests with build_jaxlib=wheel / windows x86, py3.12, x64=0

Ref: https://github.com/jax-ml/jax/actions/runs/34508811981/job/102977621176

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->