### PR TITLE
[ROCm] Reduce ROCm RBE bazel test jobs to 32

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -72,7 +72,7 @@ build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --remote_download_outputs=minimal
 
 test:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --jobs=64
+test:rocm_rbe --jobs=32
 test:rocm_rbe --strategy=TestRunner=remote,local
 test:rocm_rbe --worker_sandboxing=true
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1


### PR DESCRIPTION
## What

Lowers `--jobs` for the `rocm_rbe` Bazel test config from 64 back to 32.

## Why

#40427 raised this to 64 at the same time it enabled a much larger set of ROCm
Bazel test targets. This walks the concurrency back to 32 so we can compare RBE
scheduling behaviour between the two settings.

## How

One-line change in `build/rocm/rocm.bazelrc`. No workflow or target-list changes.

## Test plan

- ROCm Bazel presubmit legs on this PR exercise the new setting directly.
