### PR TITLE
[Mosaic GPU] Remove the swizzle size check for 1CTA M=64 MMA

### DIFF
--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -302,13 +302,6 @@ def mma(
       n_lane_groups = 1
     else:
       n_lane_groups = 2
-      # We can't split N into groups if we would partition it below the tile size.
-      # TODO: We only need to check this if N is the minormost dim in B.
-      if 8 * b_swizzle // utils.bitwidth(a_element_type) > n // n_lane_groups:
-        raise ValueError(
-            f"Swizzle={b_swizzle} is too big for MMA with M=64. Try"
-            " lowering it."
-        )
   else:
     raise ValueError(f"Only M=128 and M=64 are supported for MMA, but got M={m}")
   f32 = ir.F32Type.get()

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -1891,7 +1891,9 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
       self.skipTest("swizzle too large for input (lhs)")
     n_steps = 2 if kwargs["m"] == 64 else 1
     n_instr_size = kwargs["n"] * in_bytewidth // n_steps
-    if n_instr_size < swizzle or n_instr_size % swizzle != 0:
+    if not kwargs["rhs_transpose"] and (
+        n_instr_size < swizzle or n_instr_size % swizzle != 0
+    ):
       self.skipTest("swizzle doesn't work with this instruction size")
     if dtypes.itemsize_bits(kwargs["in_jax_dtype"]) <= 8 and kwargs["n"] == swizzle:
       self.skipTest("Only 8-bit and larger inputs are supported for MMA")
@@ -1920,7 +1922,9 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
       self.skipTest("swizzle too large for input (lhs)")
     n_steps = 2 if kwargs["m"] == 64 else 1
     n_instr_size = kwargs["n"] * in_bytewidth // n_steps
-    if n_instr_size < swizzle or n_instr_size % swizzle != 0:
+    if not kwargs["rhs_transpose"] and (
+        n_instr_size < swizzle or n_instr_size % swizzle != 0
+    ):
       self.skipTest("swizzle doesn't work with this instruction size")
     if dtypes.itemsize_bits(kwargs["in_jax_dtype"]) <= 8 and kwargs["n"] == swizzle:
       self.skipTest("Only 8-bit and larger inputs are supported for MMA")


### PR DESCRIPTION
This pr removes the swizzle size check for 1CTA M=64 MMA in tcgen05.mma (resolves the TODO next to it).

- The check rejected any B layout whose per-instruction N (N/2) was smaller than the swizzle atom, but the atom only constrains N when N is the contiguous dimension of B. For K-contiguous B ((N, K)) the MMA is valid, and the N-contiguous case is still rejected by mma_utils.create_descriptor.
- test_mma_basic_float and test_mma_basic_int now skip the swizzle-size cases only for N-contiguous B, so the K-contiguous configurations run.