### PR TITLE
[autodiff] fix first, second, and higher-order gradients of i0 and i1 at 0.0

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6139,21 +6139,63 @@ def i0(x: ArrayLike) -> Array:
     >>> jnp.i0(x)
     Array([2.2795851, 1.266066 , 1.0000001, 1.266066 , 2.2795851], dtype=float32)
   """
-  x_arr, = util.promote_args_inexact("i0", x)
-  if not issubdtype(x_arr.dtype, np.floating):
-    raise ValueError(f"Unsupported input type to jax.numpy.i0: {x_arr.dtype}")
-  return _i0(x_arr)
+  x, = util.promote_args_inexact("i0", x)
+  if not issubdtype(x.dtype, np.floating):
+    raise ValueError(f"Unsupported input type to jax.numpy.i0: {x.dtype}")
+  return i0_impl(x)
+
+
+@partial(custom_jvp, nondiff_argnums=(0,))
+def _i1_maclaurin(k: int, x: Array) -> Array:
+  # compute the kth derivative of i1 evaluated near zero using a two-term
+  # Maclaurin series.
+  if k % 2 == 0:
+    m = (k + 1) // 2
+    c = math.comb(k + 1, m) / (2 ** (k + 1))
+    return lax.mul(lax._const(x, c), x)
+  else:
+    m = k // 2
+    c = math.comb(k, m) / (2 ** k)
+    return lax.full_like(x, c)
+
+@_i1_maclaurin.defjvp
+def _i1_maclaurin_jvp(k: int, primals: tuple[Array], tangents: tuple[Array]) -> tuple[Array, Array]:
+  (x,), (t,) = primals, tangents
+  return _i1_maclaurin(k, x), lax.mul(_i1_maclaurin(k + 1, x), t)
 
 
 @custom_jvp
-def _i0(x):
+def i1_impl(x: Array) -> Array:
+  return lax.mul(lax.exp(lax.abs(x)), lax_special.bessel_i1e(x))
+
+@i1_impl.defjvp
+def i1_impl_jvp(primals: tuple[Array], tangents: tuple[Array]) -> tuple[Array, Array]:
+  # A closed-form JVP using Bessel recurrence (e.g. i1'(x) = i0(x) - i1(x)/x)
+  # is not viable due to the 0/0 singularity at x = 0. Meanwhile, autodiff
+  # through exp(abs(x)) * bessel_i1e(x) fails for higher-order derivatives
+  # near 0 due to (1) the cusp in abs(x) and (2) catastrophic cancellation when
+  # evaluating (i0e(x) - i1e(x)/x) / x^2 in floating-point arithmetic.
+  # We therefore use a recursive two-term Maclaurin series approximation for
+  # |x| <= sqrt(eps), where the series truncation error is strictly below
+  # machine precision.
+  primal_out, tangent_out = api.jvp(i1_impl.fun, primals, tangents)
+  x, = primals
+  t, = tangents
+  cutoff = math.sqrt(dtypes.finfo(x.dtype).eps)
+  use_series = lax.le(lax.abs(x), lax._const(x, cutoff))
+  return primal_out, where(use_series, lax.mul(_i1_maclaurin(1, x), t), tangent_out)
+
+
+@custom_jvp
+def i0_impl(x: Array) -> Array:
   abs_x = lax.abs(x)
   return lax.mul(lax.exp(abs_x), lax_special.bessel_i0e(abs_x))
 
-@_i0.defjvp
-def _i0_jvp(primals, tangents):
-  primal_out, tangent_out = api.jvp(_i0.fun, primals, tangents)
-  return primal_out, where(primals[0] == 0, 0.0, tangent_out)
+@i0_impl.defjvp
+def i0_impl_jvp(primals: tuple[Array], tangents: tuple[Array]) -> tuple[Array, Array]:
+  x, = primals
+  x_dot, = tangents
+  return i0_impl(x), lax.mul(x_dot, i1_impl(x))
 
 @export
 def ix_(*args: ArrayLike) -> tuple[Array, ...]:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -33,6 +33,7 @@ from jax._src.api import jit, jvp, vmap
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.lax.special import ndtr as _ndtr
 from jax._src.numpy import einsum as jnp_einsum
+from jax._src.numpy import lax_numpy
 from jax._src.numpy import vectorize as jnp_vectorize
 from jax._src.numpy.util import promote_args_complex, promote_args_inexact, promote_dtypes_inexact
 from jax._src.ops import special as ops_special
@@ -1803,7 +1804,9 @@ def i0(x: ArrayLike) -> Array:
     - :func:`jax.scipy.special.i1e`
   """
   x, = promote_args_inexact("i0", x)
-  return lax.mul(lax.exp(lax.abs(x)), lax.bessel_i0e(x))
+  if not jnp.issubdtype(x.dtype, np.floating):
+    raise ValueError(f"Unsupported input type to jax.scipy.special.i0: {x.dtype}")
+  return lax_numpy.i0_impl(x)
 
 
 def i1e(x: ArrayLike) -> Array:
@@ -1853,7 +1856,9 @@ def i1(x: ArrayLike) -> Array:
     - :func:`jax.scipy.special.i1e`
   """
   x, = promote_args_inexact("i1", x)
-  return lax.mul(lax.exp(lax.abs(x)), lax.bessel_i1e(x))
+  if not jnp.issubdtype(x.dtype, np.floating):
+    raise ValueError(f"Unsupported input type to jax.scipy.special.i1: {x.dtype}")
+  return lax_numpy.i1_impl(x)
 
 def _bessel_jn_scan_body_fun(carry, k):
   f0, f1, bs, z = carry

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -17,6 +17,7 @@ import collections
 import functools
 from functools import partial
 import itertools
+import math
 import operator
 from typing import NamedTuple
 from unittest import SkipTest
@@ -673,10 +674,29 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self.assertIsInstance(b * a, MyArray)
     self.assertIsInstance(jax.jit(operator.mul)(b, a), MyArray)
 
-  def testI0Grad(self):
-    # Regression test for https://github.com/jax-ml/jax/issues/11479
-    dx = jax.grad(jax.numpy.i0)(0.0)
-    self.assertArraysEqual(dx, 0.0)
+  @jtu.sample_product(
+      order=range(1, 6),
+  )
+  def testI0Grad(self, order):
+    # Regression test for https://github.com/jax-ml/jax/issues/11479 & 40627
+    # Higher-order gradients at zero should match the Maclaurin series
+    expected = 0.0 if order % 2 else math.comb(order, order // 2) / (4 ** (order // 2))
+    f = jax.numpy.i0
+    for _ in range(order):
+      f = jax.grad(f)
+    self.assertAllClose(f(0.0), expected)
+    self.assertAllClose(jax.jit(f)(0.0), expected)
+
+    sub_eps = dtypes.finfo(dtypes.default_float_dtype()).eps * 0.1
+    x = jnp.array([-1.0, -sub_eps, 0.0, sub_eps, 1.0])
+    out = jax.vmap(f)(x)
+    self.assertAllClose(out[2], expected)
+    if order % 2:
+      self.assertAllClose(out[0], -out[4])
+      self.assertAllClose(out[1], -out[3])
+    else:
+      self.assertAllClose(out[0], out[4])
+      self.assertAllClose(out[1], out[3])
 
   @jtu.sample_product(
       shape=all_shapes,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -15,6 +15,7 @@
 import collections
 import functools
 import itertools
+import math
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -523,6 +524,36 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     self.assertAllClose(lsp_special.gamma(z), osp_special.gamma(z),
                         atol=1e-5, rtol=rtol)
 
+  @parameterized.parameters(range(1, 5))
+  def test_i0_gradients(self, order):
+    # Regression test for https://github.com/jax-ml/jax/issues/40627 & 40628
+    def d_i0(x, n=order):
+      """Closed form of the nth derivative of i0(x)"""
+      return sum(math.comb(n, k) * osp_special.iv(abs(2 * k - n), x) for k in range(n + 1)) / (2 ** n)
+
+    eps = dtypes.finfo(dtypes.default_float_dtype()).eps
+    x = np.array([0.0, eps * 0.01, eps * 0.1, eps, eps * 10, eps * 100, 1.0])
+    args_maker = lambda: [x]
+    f = jax.scipy.special.i0
+    for _ in range(order):
+      f = jax.grad(f)
+    self._CheckAgainstNumpy(jax.vmap(f), d_i0, args_maker, rtol=1e-5)
+    self._CompileAndCheck(jax.vmap(f), args_maker, rtol=1e-5)
+
+  @parameterized.parameters(range(1, 5))
+  def test_i1_gradients(self, order):
+    def d_i1(x, n=order):
+      """Closed form of the nth derivative of i1(x)"""
+      return sum(math.comb(n + 1, k) * osp_special.iv(abs(2 * k - n - 1), x) for k in range(n + 2)) / (2 ** (n + 1))
+
+    eps = dtypes.finfo(dtypes.default_float_dtype()).eps
+    x = np.array([0.0, eps * 0.01, eps * 0.1, eps, eps * 10, eps * 100, 1.0])
+    args_maker = lambda: [x]
+    f = jax.scipy.special.i1
+    for _ in range(order):
+      f = jax.grad(f)
+    self._CheckAgainstNumpy(jax.vmap(f), d_i1, args_maker, rtol=1e-5)
+    self._CompileAndCheck(jax.vmap(f), args_maker, rtol=1e-5)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #40627 and #40628.

Previously, the JVP rule for `jax.numpy.i0` was returning a constant zero for `x=0.0`, which led to incorrect higher-order derivatives. I explored a few solutions, but arrived on using a maclaurin series approach for the JVP of i1, similar to the approach used for `sinc` which has similar autodiff challenges at `x=0.0`.