### PR TITLE
Include jax_high_dynamic_range_gumbel in the JIT cache key

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -2312,6 +2312,7 @@ use_high_dynamic_range_gumbel = bool_state(
     default=False,
     help='If True, gumbel noise draws two samples to cover low probability '
          'events with more precision.',
+    include_in_jit_key=True,
     include_in_trace_context=True,
 )
 

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -916,6 +916,25 @@ class DistributionsTest(RandomTestBase):
     cdf_probs = [x / (num_samples * num_groups) for x in pts]
     np.testing.assert_allclose(cdf_probs, probs, rtol=0.25, atol=0)
 
+  def testGumbelConfigUpdateInvalidatesJitCache(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40609:
+    # jax_high_dynamic_range_gumbel must be part of the JIT cache key, so
+    # changing it retraces callables that invoke jax.random.gumbel.
+    key = self.make_key(0)
+    with jtu.global_config_context(jax_high_dynamic_range_gumbel=False):
+      f = jax.jit(lambda k: random.gumbel(k, (4,)))
+      low = np.asarray(f(key))
+      self.assertEqual(f._cache_size(), 1)
+
+      jax.config.update("jax_high_dynamic_range_gumbel", True)
+      high = np.asarray(f(key))
+      self.assertEqual(f._cache_size(), 2)
+
+      # The recompiled callable must use the new sampling mode.
+      fresh_high = np.asarray(jax.jit(lambda k: random.gumbel(k, (4,)))(key))
+    self.assertFalse(np.array_equal(low, high))
+    self.assertTrue(np.array_equal(high, fresh_high))
+
   def testSafeIntToFloat(self):
     dtype = np.float32
     finfo = dtypes.finfo(dtype)


### PR DESCRIPTION
jax.random.gumbel reads the jax_high_dynamic_range_gumbel config at trace time, but the flag had include_in_trace_context=True without include_in_jit_key=True. Flipping it between calls to a jitted function reused the stale executable, so it kept sampling in the old mode. #40609 has a minimal repro and the root cause.

This adds include_in_jit_key=True (same as precedent flags like jax_softmax_custom_jvp) and a regression test that checks the JIT cache grows to 2 after the config update and that the recompiled callable matches a fresh compile.

### Testing

- The new test fails on the unfixed baseline (AssertionError: 1 != 2 on the cache size) and passes with the fix.
- pytest -n auto tests/random_lax_test.py -k Gumbel: 5 passed, and 7 passed with JAX_ENABLE_X64=True.
- Full tests/random_lax_test.py: 642 passed, 0 failed (739 passed with x64).
- tests/config_test.py: 10 passed, 1 skipped (TPU-only).
- Full CPU suite (pytest -n auto tests/, both CI env variants): 24508 passed / 2 failed and 23208 passed / 2 failed. The 2 failures in each run are environmental (this machine has a visible NVIDIA GPU with a CPU-only jaxlib, which trips two no-GPU-warning tests) and fail identically on the unmodified baseline.
- pre-commit run --all-files: all 12 hooks pass (ruff, pyrefly, copyright, and the generic hooks).

Tested on CPU (jaxlib 0.11.1); GPU/TPU paths and the bazel-based workflows not exercised.

Fixes #40609
