### PR TITLE
[sparse] Fix incorrect reverse-mode derivative for transposed COO and CSR matmat/matvec

### DIFF
--- a/jax/experimental/sparse/coo.py
+++ b/jax/experimental/sparse/coo.py
@@ -493,9 +493,8 @@ def _coo_matvec_transpose(ct, data, row, col, v, *, spinfo, transpose):
     return data, row, col, _coo_matvec(data, row, col, ct, spinfo=spinfo, transpose=not transpose)
   else:
     v = jnp.asarray(v)
-    # The following line does this, but more efficiently:
-    # return _coo_extract(row, col, jnp.outer(ct, v)), row, col, v
-    return ct[row] * v[col], row, col, v
+    r, c = (col, row) if transpose else (row, col)
+    return ct[r] * v[c], row, col, v
 
 ad.defjvp(coo_matvec_p, _coo_matvec_jvp_mat, None, None, _coo_matvec_jvp_vec)
 ad.primitive_transposes[coo_matvec_p] = _coo_matvec_transpose
@@ -613,7 +612,8 @@ def _coo_matmat_transpose(ct, data, row, col, B, *, spinfo, transpose):
     return data, row, col, _coo_matmat(data, row, col, ct, spinfo=spinfo, transpose=not transpose)
   else:
     B = jnp.asarray(B)
-    return (ct[row] * B[col]).sum(1), row, col, B
+    r, c = (col, row) if transpose else (row, col)
+    return (ct[r] * B[c]).sum(1), row, col, B
 
 ad.defjvp(coo_matmat_p, _coo_matmat_jvp_left, None, None, _coo_matmat_jvp_right)
 ad.primitive_transposes[coo_matmat_p] = _coo_matmat_transpose

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -510,8 +510,9 @@ def _csr_matvec_transpose(ct, data, indices, indptr, v, *, shape, transpose):
   else:
     v = jnp.asarray(v)
     # The following lines do this, but more efficiently.
-    # return _csr_extract(indices, indptr, jnp.outer(ct, v)), indices, indptr, v
     row, col = _csr_to_coo(indices, indptr)
+    if transpose:
+      row, col = col, row
     return ct[row] * v[col], indices, indptr, v
 
 ad.defjvp(csr_matvec_p, _csr_matvec_jvp_mat, None, None, _csr_matvec_jvp_vec)
@@ -618,6 +619,8 @@ def _csr_matmat_transpose(ct, data, indices, indptr, B, *, shape, transpose):
   else:
     B = jnp.asarray(B)
     row, col = _csr_to_coo(indices, indptr)
+    if transpose:
+      row, col = col, row
     return (ct[row] * B[col]).sum(1), indices, indptr, B
 
 ad.defjvp(csr_matmat_p, _csr_matmat_jvp_left, None, None, _csr_matmat_jvp_right)

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -466,14 +466,17 @@ class cuSparseTest(sptu.SparseTestCase):
     self.assertArraysEqual(M_out, M)
 
   @jtu.sample_product(
-    [dict(shape=shape, bshape=bshape)
+    [
+      dict(shape=shape, bshape=bshape, transpose=transpose)
       for shape in [(5, 8), (8, 5), (5, 5), (8, 8)]
-      for bshape in [shape[-1:] + s for s in [(), (1,), (3,)]]
+      for transpose in [True, False]
+      for bshape in [(shape[0] if transpose else shape[1],) + s for s in [(), (1,), (3,)]]
     ],
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
   )
   @jax.default_matmul_precision("float32")
-  def test_coo_matmul_ad(self, shape, dtype, bshape):
+  def test_coo_matmul_ad(self, shape, dtype, bshape, transpose):
+    op = lambda M: M.T if transpose else M
     coo_matmul = sparse_coo._coo_matvec if len(bshape) == 1 else sparse_coo._coo_matmat
     tol = {np.float32: 1E-5, np.float64: 1E-12, np.complex64: 1E-5, np.complex128: 1E-12}
 
@@ -487,8 +490,8 @@ class cuSparseTest(sptu.SparseTestCase):
     spinfo = sparse_coo.COOInfo(shape=M.shape, rows_sorted=True)
 
     # Forward-mode with respect to the vector
-    f_dense = lambda x: M @ x
-    f_sparse = lambda x: coo_matmul(data, row, col, x, spinfo=spinfo)
+    f_dense = lambda x: op(M) @ x
+    f_sparse = lambda x: coo_matmul(data, row, col, x, spinfo=spinfo, transpose=transpose)
     v_sparse, t_sparse = jax.jvp(f_sparse, [x], [xdot])
     v_dense, t_dense = jax.jvp(f_dense, [x], [xdot])
     self.assertAllClose(v_sparse, v_dense, atol=tol, rtol=tol)
@@ -503,13 +506,70 @@ class cuSparseTest(sptu.SparseTestCase):
     self.assertAllClose(out_dense, out_sparse, atol=tol, rtol=tol)
 
     # Forward-mode with respect to nonzero elements of the matrix
-    f_sparse = lambda data: coo_matmul(data, row, col, x, spinfo=spinfo)
-    f_dense = lambda data: sparse_coo._coo_todense(data, row, col, spinfo=spinfo) @ x
+    f_sparse = lambda data: coo_matmul(data, row, col, x, spinfo=spinfo, transpose=transpose)
+    f_dense = lambda data: op(sparse_coo._coo_todense(data, row, col, spinfo=spinfo)) @ x
     data = rng((len(data),), data.dtype)
     data_dot = rng((len(data),), data.dtype)
     v_sparse, t_sparse = jax.jvp(f_sparse, [data], [data_dot])
     v_dense, t_dense = jax.jvp(f_dense, [data], [data_dot])
 
+    self.assertAllClose(v_sparse, v_dense, atol=tol, rtol=tol)
+    self.assertAllClose(t_sparse, t_dense, atol=tol, rtol=tol)
+
+    # Reverse-mode with respect to nonzero elements of the matrix
+    primals_dense, vjp_dense = jax.vjp(f_dense, data)
+    primals_sparse, vjp_sparse = jax.vjp(f_sparse, data)
+    out_dense, = vjp_dense(primals_dense)
+    out_sparse, = vjp_sparse(primals_sparse)
+    self.assertAllClose(primals_dense[0], primals_sparse[0], atol=tol, rtol=tol)
+    self.assertAllClose(out_dense, out_sparse, atol=tol, rtol=tol)
+
+  @jtu.sample_product(
+    [
+      dict(shape=shape, bshape=bshape, transpose=transpose)
+      for shape in [(5, 8), (8, 5), (5, 5), (8, 8)]
+      for transpose in [True, False]
+      for bshape in [(shape[0] if transpose else shape[1],) + s for s in [(), (1,), (3,)]]
+    ],
+    dtype=jtu.dtypes.floating + jtu.dtypes.complex,
+  )
+  @jax.default_matmul_precision("float32")
+  def test_csr_matmul_ad(self, shape, dtype, bshape, transpose):
+    op = lambda M: M.T if transpose else M
+    csr_matmul = sparse_csr._csr_matvec if len(bshape) == 1 else sparse_csr._csr_matmat
+    tol = {np.float32: 1E-5, np.float64: 1E-12, np.complex64: 1E-5, np.complex128: 1E-12}
+
+    rng = sptu.rand_sparse(self.rng(), post=jnp.array)
+    rng_b = jtu.rand_default(self.rng())
+
+    M = rng(shape, dtype)
+    data, indices, indptr = sparse_csr._csr_fromdense(M, nse=(M != 0).sum())
+    x = rng_b(bshape, dtype)
+    xdot = rng_b(bshape, dtype)
+
+    # Forward-mode with respect to the vector
+    f_dense = lambda x: op(M) @ x
+    f_sparse = lambda x: csr_matmul(data, indices, indptr, x, shape=M.shape, transpose=transpose)
+    v_sparse, t_sparse = jax.jvp(f_sparse, [x], [xdot])
+    v_dense, t_dense = jax.jvp(f_dense, [x], [xdot])
+    self.assertAllClose(v_sparse, v_dense, atol=tol, rtol=tol)
+    self.assertAllClose(t_sparse, t_dense, atol=tol, rtol=tol)
+
+    # Reverse-mode with respect to the vector
+    primals_dense, vjp_dense = jax.vjp(f_dense, x)
+    primals_sparse, vjp_sparse = jax.vjp(f_sparse, x)
+    out_dense, = vjp_dense(primals_dense)
+    out_sparse, = vjp_sparse(primals_sparse)
+    self.assertAllClose(primals_dense[0], primals_sparse[0], atol=tol, rtol=tol)
+    self.assertAllClose(out_dense, out_sparse, atol=tol, rtol=tol)
+
+    # Forward-mode with respect to nonzero elements of the matrix
+    f_sparse = lambda data: csr_matmul(data, indices, indptr, x, shape=M.shape, transpose=transpose)
+    f_dense = lambda data: op(sparse_csr._csr_todense(data, indices, indptr, shape=M.shape)) @ x
+    data = rng((len(data),), data.dtype)
+    data_dot = rng((len(data),), data.dtype)
+    v_sparse, t_sparse = jax.jvp(f_sparse, [data], [data_dot])
+    v_dense, t_dense = jax.jvp(f_dense, [data], [data_dot])
     self.assertAllClose(v_sparse, v_dense, atol=tol, rtol=tol)
     self.assertAllClose(t_sparse, t_dense, atol=tol, rtol=tol)
 


### PR DESCRIPTION
Fixes #40625.

### Background and Problem
In `jax.experimental.sparse`, sparse matrix-matrix and matrix-vector multiplications (`coo_matmat`, `coo_matvec`, `csr_matmat`, `csr_matvec`) support an optional `transpose: bool` flag. When `transpose=True`, the primal computes:
- Matrix-matrix: $C = A^T B$
- Matrix-vector: $y = A^T v$

For a non-zero element of $A$ at position $(row[p], col[p])$:
- In $A^T$, $col[p]$ represents the row index (matching cotangent $ct$), and $row[p]$ represents the column index (matching $B$ or $v$).
- Differentiating with respect to the non-zero sparse data of $A$ requires contracting $ct[col]$ with $B[row]$ (or $v[row]$).

Previously, the primitive transpose rules (`_coo_matmat_transpose`, `_coo_matvec_transpose`, `_csr_matmat_transpose`, `_csr_matvec_transpose`) always contracted $ct[row]$ with $B[col]$ (or $v[col]$), completely ignoring `transpose`. Consequently:
1. Whenever $row \neq col$ (e.g. non-symmetric or rectangular sparse matrices), the reverse-mode derivative with respect to the matrix data was computed with incorrect index associations, yielding wrong gradients.
2. In issue #40625, this caused `jax.grad` on a scalar loss to return `-35.0` instead of `-1379.0`.

### Solution
1. In `_coo_matvec_transpose` and `_coo_matmat_transpose` (`jax/experimental/sparse/coo.py`), swap row and col indices when `transpose=True`:
   ```python
   r, c = (col, row) if transpose else (row, col)
   ```
2. In `_csr_matvec_transpose` and `_csr_matmat_transpose` (`jax/experimental/sparse/csr.py`), swap row and col indices when `transpose=True`:
   ```python
   row, col = _csr_to_coo(indices, indptr)
   if transpose:
     row, col = col, row
   ```
3. Update `test_coo_matmul_ad` in `tests/sparse_test.py` to parameterize across `transpose=[True, False]` and add `test_csr_matmul_ad` parameterized across `transpose=[True, False]`, testing both forward-mode (`jvp`) and reverse-mode (`vjp`) autodiff with respect to both inputs (vectors/matrices and sparse non-zero data).

### Verification
- Tested locally with pytest on `tests/sparse_test.py -k "matmul_ad"`: all 20 parameterized test cases pass.
- Full COO and CSR test suite (`tests/sparse_test.py -k "coo or csr"`): all 233 passed.
