### PR TITLE
[lax] Propagate mode in _scatter_extremal_jvp to fix invalid gradients with clip/drop (fixes #40626)

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -3102,10 +3102,10 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
     # tangents for the values in updates.
 
     initial_vals = gather(
-        operand, indices, gather_dnums, slice_sizes)
+        operand, indices, gather_dnums, slice_sizes, mode=mode)
 
     target_vals = gather(
-        val_out, indices, gather_dnums, slice_sizes)
+        val_out, indices, gather_dnums, slice_sizes, mode=mode)
 
     successful_updates = (updates == target_vals)
     retained_values = (initial_vals == target_vals)
@@ -3115,23 +3115,24 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
             lax._zeros(operand), indices,
             lax.select(successful_updates, lax._ones(updates),
                        lax._zeros(updates)),
-            scatter_dnums),
+            scatter_dnums, mode=mode),
         indices,
         gather_dnums,
-        slice_sizes)
+        slice_sizes, mode=mode)
 
     num_refs = gather(
         scatter_add(lax._zeros(operand),
                     indices,
                     lax._ones(updates),
-                    scatter_dnums),
+                    scatter_dnums, mode=mode),
         indices,
         gather_dnums,
-        slice_sizes)
+        slice_sizes, mode=mode)
 
+    safe_num_updates = lax.select(num_updates > 0, num_updates, lax._ones(num_updates))
     updates_normalizer = lax.select(retained_values,
                                     1.0 / (num_updates + 1),
-                                    1.0 / num_updates)
+                                    1.0 / safe_num_updates)
 
     updates_coef = lax.select(successful_updates,
                               updates_normalizer,
@@ -3141,11 +3142,14 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
                                     1.0 / (num_updates + 1),
                                     lax._zeros(num_updates))
 
-    operand_coef = (-1.0 + operand_normalizer) / num_refs
+    safe_num_refs = lax.select(num_refs > 0, num_refs, lax._ones(num_refs))
+    operand_coef = lax.select(num_refs > 0,
+                              (-1.0 + operand_normalizer) / safe_num_refs,
+                              lax._zeros(num_refs))
 
     # This can be simplified once scatter has transpose implemented
     target_tangents = gather(
-        g_operand, indices, gather_dnums, slice_sizes)
+        g_operand, indices, gather_dnums, slice_sizes, mode=mode)
 
     tangent_updates = (target_tangents * operand_coef +
                        g_updates * updates_coef)

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -1181,6 +1181,48 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     y = rng(update_shape, dtype)
     check_grads(scatter_min, (x, y), 2, ["fwd", "rev"], 1e-2, 1e-2)
 
+  @jtu.sample_product(
+    op=[lax.scatter_max, lax.scatter_min],
+    mode=["clip", "fill", "drop"],
+    dtype=grad_float_dtypes,
+  )
+  def testScatterExtremalModesOutOfBounds(self, op, mode, dtype):
+    rng = jtu.rand_default(self.rng())
+    x = rng((5,), dtype)
+    y = rng((2,), dtype)
+    idxs = np.array([[-3], [8]], dtype=np.int32)
+    dnums = lax.ScatterDimensionNumbers(
+        update_window_dims=(), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))
+    scatter_fn = lambda x, y: op(x, idxs, y, dnums, mode=mode)
+    check_grads(scatter_fn, (x, y), 2, ["fwd", "rev"], 1e-2, 1e-2)
+
+  def testScatterMaxOutOfBoundsIssue40626(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40626
+    def target(t):
+      x = jnp.asarray([1.0, 3.0, 4.0])
+      u = t * jnp.asarray([1.0, -1.0]) + jnp.asarray([1.0, 4.0])
+      i = jnp.asarray([[-3], [8]], dtype=jnp.int32)
+      dnums = lax.ScatterDimensionNumbers(
+          update_window_dims=(),
+          inserted_window_dims=(0,),
+          scatter_dims_to_operand_dims=(0,),
+      )
+      y = lax.scatter_max(
+          x, i, u, dnums,
+          indices_are_sorted=True,
+          unique_indices=True,
+          mode="clip",
+      )
+      return jnp.sum(y * jnp.asarray([2.0, -1.0, 3.0]))
+
+    x = jnp.asarray(0.03125, dtype=jnp.float32)
+    g = jax.grad(target)(x)
+    self.assertFalse(jnp.isinf(g))
+    self.assertFalse(jnp.isnan(g))
+    self.assertAllClose(g, 2.0)
+
+
   def testStopGradient(self):
     def f(x):
       return lax.sin(x) * lax.cos(lax.stop_gradient(x))


### PR DESCRIPTION
Fixes #40626.

### Background & Problem
When differentiating extremal scatter operations (`jax.lax.scatter_max` and `jax.lax.scatter_min`) with `mode="clip"` and out-of-bounds indices, `jax.grad` could return infinite or incorrect gradients.

In `_scatter_extremal_jvp` (`jax/_src/lax/slicing.py`), although `mode=mode` was passed to the final `scatter_add`, all internal intermediate `gather` and `scatter_add` calls (used to compute `initial_vals`, `target_vals`, `num_updates`, `num_refs`, and `target_tangents`) omitted `mode=mode`, defaulting to `GatherScatterMode.PROMISE_IN_BOUNDS`.

Consequently:
1. Intermediate operations failed to record references for clipped indices when indices were out of bounds, leaving `num_refs = 0`.
2. When computing `operand_coef = (-1.0 + operand_normalizer) / num_refs`, evaluating `(-1.0) / 0 = -inf` produced `inf` gradients for valid clipped indices.
3. Similarly, for `mode="drop"`, dropped updates could result in `num_updates = 0` or `num_refs = 0`.

### Solution
1. Propagated `mode=mode` to all intermediate `gather` and `scatter_add` calls in `_scatter_extremal_jvp`.
2. Added safe zero-guards (`safe_num_updates` and `safe_num_refs`) when dividing by `num_updates` and `num_refs`.
3. Added parameterized unit tests (`testScatterExtremalModesOutOfBounds`) for `scatter_max` and `scatter_min` with modes `clip`, `fill`, and `drop`, along with a regression test for #40626.
