### PR TITLE
[sparse] Mask padded entries in _coo_fromdense_jvp and _csr_fromdense_jvp (fixes #40624)

### DIFF
--- a/jax/experimental/sparse/coo.py
+++ b/jax/experimental/sparse/coo.py
@@ -360,7 +360,8 @@ def _coo_fromdense_jvp(primals, tangents, *, nse, index_dtype):
   if type(Mdot) is ad.Zero:
     data_dot = ad.p2tz(data)
   else:
-    data_dot = _coo_extract(row, col, Mdot)
+    true_nonzeros = jnp.arange(nse) < (M != 0).sum()
+    data_dot = jnp.where(true_nonzeros, _coo_extract(row, col, Mdot), 0)
 
   tangents_out = (data_dot, ad.p2tz(row), ad.p2tz(col))
 

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -394,7 +394,8 @@ def _csr_fromdense_jvp(primals, tangents, *, nse, index_dtype):
   if type(Mdot) is ad.Zero:
     data_dot = ad.p2tz(data)
   else:
-    data_dot = _csr_extract(indices, indptr, Mdot)
+    true_nonzeros = jnp.arange(nse) < (M != 0).sum()
+    data_dot = jnp.where(true_nonzeros, _csr_extract(indices, indptr, Mdot), 0)
 
   tangents_out = (data_dot, ad.p2tz(indices), ad.p2tz(indptr))
 

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -94,11 +94,13 @@ class cuSparseTest(sptu.SparseTestCase):
   @jtu.sample_product(
     shape=[(5, 8), (8, 5), (5, 5), (8, 8)],
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
+    nse_padding=[0, 3],
   )
-  def test_csr_fromdense_ad(self, shape, dtype):
+  def test_csr_fromdense_ad(self, shape, dtype, nse_padding):
     rng = sptu.rand_sparse(self.rng(), post=jnp.array)
     M = rng(shape, dtype)
-    nse = (M != 0).sum()
+    nnz = (M != 0).sum()
+    nse = nnz + nse_padding
     f = lambda M: sparse_csr._csr_fromdense(M, nse=nse)
 
     # Forward-mode
@@ -106,7 +108,8 @@ class cuSparseTest(sptu.SparseTestCase):
     self.assertArraysEqual(primals[0], f(M)[0])
     self.assertArraysEqual(primals[1], f(M)[1])
     self.assertArraysEqual(primals[2], f(M)[2])
-    self.assertArraysEqual(tangents[0], jnp.ones(nse, dtype=dtype))
+    expected_tangents = jnp.where(jnp.arange(nse) < nnz, jnp.ones(nse, dtype=dtype), 0)
+    self.assertArraysEqual(tangents[0], expected_tangents)
     self.assertEqual(tangents[1].dtype, dtypes.float0)
     self.assertEqual(tangents[2].dtype, dtypes.float0)
 
@@ -441,11 +444,13 @@ class cuSparseTest(sptu.SparseTestCase):
   @jtu.sample_product(
     shape=[(5, 8), (8, 5), (5, 5), (8, 8)],
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
+    nse_padding=[0, 3],
   )
-  def test_coo_fromdense_ad(self, shape, dtype):
+  def test_coo_fromdense_ad(self, shape, dtype, nse_padding):
     rng = sptu.rand_sparse(self.rng(), post=jnp.array)
     M = rng(shape, dtype)
-    nse = (M != 0).sum()
+    nnz = (M != 0).sum()
+    nse = nnz + nse_padding
     f = lambda M: sparse_coo._coo_fromdense(M, nse=nse)
 
     # Forward-mode
@@ -453,7 +458,8 @@ class cuSparseTest(sptu.SparseTestCase):
     self.assertArraysEqual(primals[0], f(M)[0])
     self.assertArraysEqual(primals[1], f(M)[1])
     self.assertArraysEqual(primals[2], f(M)[2])
-    self.assertArraysEqual(tangents[0], jnp.ones(nse, dtype=dtype))
+    expected_tangents = jnp.where(jnp.arange(nse) < nnz, jnp.ones(nse, dtype=dtype), 0)
+    self.assertArraysEqual(tangents[0], expected_tangents)
     self.assertEqual(tangents[1].dtype, dtypes.float0)
     self.assertEqual(tangents[2].dtype, dtypes.float0)
 
@@ -464,6 +470,25 @@ class cuSparseTest(sptu.SparseTestCase):
     self.assertArraysEqual(primals[1], f(M)[1])
     self.assertArraysEqual(primals[2], f(M)[2])
     self.assertArraysEqual(M_out, M)
+
+  def test_coo_fromdense_padded_second_derivative_issue40624(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40624
+    def target(t):
+      z = jnp.zeros_like(t)
+      a = jnp.stack((t + 1, z, -t, z, z, t * t + 2)).reshape((2, 3)).T
+      out = sparse_coo.coo_fromdense(
+          a,
+          nse=5,
+          index_dtype=jnp.int32,
+      )
+      return jnp.sum(out.data ** 2)
+
+    x = jnp.asarray(0.02, dtype=jnp.float32)
+    # Target function with true nonzeros: (t + 1)**2 + t**2 + (t**2 + 2)**2
+    # At t = 0.02, expected second derivative is 12.0048
+    second_deriv = jax.grad(jax.grad(target))(x)
+    self.assertAllClose(second_deriv, 12.0048, atol=1e-3, rtol=1e-3)
+
 
   @jtu.sample_product(
     [dict(shape=shape, bshape=bshape)


### PR DESCRIPTION
Fixes #40624.

### Background & Problem
When converting a dense array to sparse COO or CSR format (`coo_fromdense` or `csr_fromdense`) where `nse` exceeds the actual number of nonzero entries (`nnz`), `_coo_fromdense_impl` and `_csr_fromdense_impl` properly set padded elements in `data` to 0.

However, in `_coo_fromdense_jvp` and `_csr_fromdense_jvp`:
- `_coo_extract(row, col, Mdot)` and `_csr_extract(indices, indptr, Mdot)` extracted tangent values at all `nse` indices without masking out the padding.
- Because padded index entries default to `(0, 0)` in `COO` (or clamped index boundaries in `CSR`), tangents of the dense matrix at those coordinates leaked into the padded entries of `data_dot`.
- When computing second-order derivatives (such as `grad(grad(target))` in #40624) or differentiating linear functions over `out.data`, these phantom tangents leaked into the derivative, returning incorrect values (e.g. `16.0048` instead of `12.0048`).

### Solution
1. In `_coo_fromdense_jvp` and `_csr_fromdense_jvp`, mask tangents with `true_nonzeros = jnp.arange(nse) < (M != 0).sum()`, ensuring padded tangent entries are always `0`.
2. Parameterize `test_coo_fromdense_ad` and `test_csr_fromdense_ad` to test `nse_padding=[0, 3]`.
3. Add a dedicated regression test `test_coo_fromdense_padded_second_derivative_issue40624`.
